### PR TITLE
Release main/Smdn.Net.AddressResolution-1.0.0-rc1

### DIFF
--- a/doc/api-list/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution-net7.0.apilist.cs
+++ b/doc/api-list/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution-net7.0.apilist.cs
@@ -1,23 +1,25 @@
-// Smdn.Net.AddressResolution.dll (Smdn.Net.AddressResolution-1.0.0-preview6)
+// Smdn.Net.AddressResolution.dll (Smdn.Net.AddressResolution-1.0.0-rc1)
 //   Name: Smdn.Net.AddressResolution
 //   AssemblyVersion: 1.0.0.0
-//   InformationalVersion: 1.0.0-preview6+867630e3d8768ccca99d991e9c0c1cca62c64c76
+//   InformationalVersion: 1.0.0-rc1+54f2767c7798db11d76ae3836009b55f701af69f
 //   TargetFramework: .NETCoreApp,Version=v7.0
 //   Configuration: Release
 //   Referenced assemblies:
 //     Microsoft.Extensions.DependencyInjection.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Microsoft.Extensions.Logging.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
+//     System.Collections, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.Collections.Concurrent, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.ComponentModel, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+//     System.ComponentModel.Primitives, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.Diagnostics.Process, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.Linq, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.Memory, Version=7.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
 //     System.Net.NetworkInformation, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+//     System.Net.Ping, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.Net.Primitives, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.Runtime, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.Runtime.InteropServices, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.Threading, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
-//     Vanara.Core, Version=3.4.13.0, Culture=neutral, PublicKeyToken=c37e4080322237fa
 //     Vanara.PInvoke.IpHlpApi, Version=3.4.13.0, Culture=neutral, PublicKeyToken=c37e4080322237fa
 //     Vanara.PInvoke.Shared, Version=3.4.13.0, Culture=neutral, PublicKeyToken=c37e4080322237fa
 //     Vanara.PInvoke.Ws2_32, Version=3.4.13.0, Culture=neutral, PublicKeyToken=c37e4080322237fa
@@ -25,6 +27,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Runtime.CompilerServices;
@@ -33,7 +37,8 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Smdn.Net;
 using Smdn.Net.AddressResolution;
-using Smdn.Net.NeighborDiscovery;
+using Smdn.Net.AddressTables;
+using Smdn.Net.NetworkScanning;
 
 namespace Smdn.Net {
   public abstract class IPNetworkProfile {
@@ -42,7 +47,7 @@ namespace Smdn.Net {
     public static IPNetworkProfile Create(IPAddress baseAddress, IPAddress subnetMask, NetworkInterface? networkInterface = null) {}
     public static IPNetworkProfile Create(IPAddress baseAddress, int prefixLength, NetworkInterface? networkInterface = null) {}
     public static IPNetworkProfile Create(NetworkInterface networkInterface) {}
-    public static IPNetworkProfile Create(Predicate<NetworkInterface> predicate) {}
+    public static IPNetworkProfile Create(Predicate<NetworkInterface> predicateForNetworkInterface) {}
 
     protected IPNetworkProfile(NetworkInterface? networkInterface) {}
 
@@ -57,27 +62,32 @@ namespace Smdn.Net {
 }
 
 namespace Smdn.Net.AddressResolution {
-  public interface IAddressResolver<TAddress, TResolvedAddress> {
+  public interface IAddressResolver<TAddress, TResolvedAddress> where TAddress : notnull where TResolvedAddress : notnull {
     void Invalidate(TAddress address);
-    ValueTask<TResolvedAddress> ResolveAsync(TAddress address, CancellationToken cancellationToken);
+    ValueTask<TResolvedAddress?> ResolveAsync(TAddress address, CancellationToken cancellationToken);
   }
 
   public class MacAddressResolver : MacAddressResolverBase {
-    protected MacAddressResolver(INeighborTable neighborTable, INeighborDiscoverer neighborDiscoverer, TimeSpan neighborDiscoveryInterval, ILogger? logger) {}
-    public MacAddressResolver(INeighborTable? neighborTable = null, INeighborDiscoverer? neighborDiscoverer = null, int neighborDiscoveryIntervalMilliseconds = -1, IServiceProvider? serviceProvider = null) {}
+    protected MacAddressResolver(IAddressTable addressTable, bool shouldDisposeAddressTable, INetworkScanner? networkScanner, bool shouldDisposeNetworkScanner, NetworkInterface? networkInterface, int maxParallelCountForRefreshInvalidatedCache, ILogger? logger) {}
+    public MacAddressResolver() {}
+    public MacAddressResolver(IAddressTable? addressTable, INetworkScanner? networkScanner, bool shouldDisposeAddressTable = false, bool shouldDisposeNetworkScanner = false, NetworkInterface? networkInterface = null, int maxParallelCountForRefreshInvalidatedCache = 3, IServiceProvider? serviceProvider = null) {}
     public MacAddressResolver(IPNetworkProfile? networkProfile, IServiceProvider? serviceProvider = null) {}
-    public MacAddressResolver(IPNetworkProfile? networkProfile, TimeSpan neighborDiscoveryInterval, IServiceProvider? serviceProvider = null) {}
-    public MacAddressResolver(TimeSpan neighborDiscoveryInterval, INeighborTable? neighborTable = null, INeighborDiscoverer? neighborDiscoverer = null, IServiceProvider? serviceProvider = null) {}
 
+    public bool CanPerformNetworkScan { get; }
     public override bool HasInvalidated { get; }
+    public TimeSpan NetworkScanInterval { get; set; }
+    public TimeSpan NetworkScanMinInterval { get; set; }
 
     protected override void Dispose(bool disposing) {}
+    public IAsyncEnumerable<AddressTableEntry> EnumerateAddressTableEntriesAsync(CancellationToken cancellationToken = default) {}
+    public IAsyncEnumerable<AddressTableEntry> EnumerateAddressTableEntriesAsync(Predicate<AddressTableEntry> predicate, CancellationToken cancellationToken = default) {}
     protected override void InvalidateCore(IPAddress ipAddress) {}
     protected override void InvalidateCore(PhysicalAddress macAddress) {}
     protected override ValueTask RefreshCacheAsyncCore(CancellationToken cancellationToken = default) {}
     protected override ValueTask RefreshInvalidatedCacheAsyncCore(CancellationToken cancellationToken = default) {}
     protected override async ValueTask<PhysicalAddress?> ResolveIPAddressToMacAddressAsyncCore(IPAddress ipAddress, CancellationToken cancellationToken) {}
     protected override async ValueTask<IPAddress?> ResolveMacAddressToIPAddressAsyncCore(PhysicalAddress macAddress, CancellationToken cancellationToken) {}
+    protected virtual async ValueTask<AddressTableEntry> SelectAddressTableEntryAsync(Predicate<AddressTableEntry> predicate, CancellationToken cancellationToken) {}
   }
 
   public abstract class MacAddressResolverBase :
@@ -115,17 +125,12 @@ namespace Smdn.Net.AddressResolution {
   }
 }
 
-namespace Smdn.Net.NeighborDiscovery {
-  public interface INeighborDiscoverer {
-    ValueTask DiscoverAsync(CancellationToken cancellationToken);
-    ValueTask DiscoverAsync(IEnumerable<IPAddress> addresses, CancellationToken cancellationToken);
+namespace Smdn.Net.AddressTables {
+  public interface IAddressTable : IDisposable {
+    IAsyncEnumerable<AddressTableEntry> EnumerateEntriesAsync(CancellationToken cancellationToken);
   }
 
-  public interface INeighborTable {
-    IAsyncEnumerable<NeighborTableEntry> EnumerateEntriesAsync(CancellationToken cancellationToken);
-  }
-
-  public enum NeighborTableEntryState : int {
+  public enum AddressTableEntryState : int {
     Delay = 4,
     Incomplete = 1,
     None = 0,
@@ -134,82 +139,121 @@ namespace Smdn.Net.NeighborDiscovery {
     Stale = 3,
   }
 
-  public sealed class ArpScanCommandNeighborDiscoverer : RunCommandNeighborDiscovererBase {
+  public sealed class IpHlpApiAddressTable : IAddressTable {
     public static bool IsSupported { get; }
 
-    public ArpScanCommandNeighborDiscoverer(IPNetworkProfile? networkProfile, IServiceProvider? serviceProvider) {}
+    public IpHlpApiAddressTable(IServiceProvider? serviceProvider = null) {}
 
-    protected override bool GetCommandLineArguments(IEnumerable<IPAddress> addressesToDiscover, out string executable, out string arguments) {}
-    protected override bool GetCommandLineArguments(out string executable, out string arguments) {}
+    [AsyncIteratorStateMachine(typeof(IpHlpApiAddressTable.<EnumerateEntriesAsync>d__6))]
+    public IAsyncEnumerable<AddressTableEntry> EnumerateEntriesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default) {}
+    void IDisposable.Dispose() {}
   }
 
-  public sealed class IpHlpApiNeighborDiscoverer : INeighborDiscoverer {
-    public IpHlpApiNeighborDiscoverer(IPNetworkProfile networkProfile, ILogger? logger = null) {}
-
-    public ValueTask DiscoverAsync(CancellationToken cancellationToken = default) {}
-    public async ValueTask DiscoverAsync(IEnumerable<IPAddress> addresses, CancellationToken cancellationToken = default) {}
-  }
-
-  public sealed class IpHlpApiNeighborTable : INeighborTable {
+  public sealed class ProcfsArpAddressTable : IAddressTable {
     public static bool IsSupported { get; }
 
-    public IpHlpApiNeighborTable(IServiceProvider? serviceProvider = null) {}
+    public ProcfsArpAddressTable(IServiceProvider? serviceProvider = null) {}
 
-    [AsyncIteratorStateMachine(typeof(IpHlpApiNeighborTable.<EnumerateEntriesAsync>d__5))]
-    public IAsyncEnumerable<NeighborTableEntry> EnumerateEntriesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default) {}
+    [AsyncIteratorStateMachine(typeof(ProcfsArpAddressTable.<EnumerateEntriesAsync>d__7))]
+    public IAsyncEnumerable<AddressTableEntry> EnumerateEntriesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default) {}
+    void IDisposable.Dispose() {}
   }
 
-  public sealed class NmapCommandNeighborDiscoverer : RunCommandNeighborDiscovererBase {
-    public static bool IsSupported { get; }
-
-    public NmapCommandNeighborDiscoverer(IPNetworkProfile networkProfile, IServiceProvider? serviceProvider) {}
-
-    protected override bool GetCommandLineArguments(IEnumerable<IPAddress> addressesToDiscover, out string executable, out string arguments) {}
-    protected override bool GetCommandLineArguments(out string executable, out string arguments) {}
-  }
-
-  public sealed class NullNeighborDiscoverer : INeighborDiscoverer {
-    public static readonly NullNeighborDiscoverer Instance; // = "Smdn.Net.NeighborDiscovery.NullNeighborDiscoverer"
-
-    public ValueTask DiscoverAsync(CancellationToken cancellationToken) {}
-    public ValueTask DiscoverAsync(IEnumerable<IPAddress> addresses, CancellationToken cancellationToken) {}
-  }
-
-  public sealed class ProcfsArpNeighborTable : INeighborTable {
-    public static bool IsSupported { get; }
-
-    public ProcfsArpNeighborTable(IServiceProvider? serviceProvider = null) {}
-
-    [AsyncIteratorStateMachine(typeof(ProcfsArpNeighborTable.<EnumerateEntriesAsync>d__6))]
-    public IAsyncEnumerable<NeighborTableEntry> EnumerateEntriesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default) {}
-  }
-
-  public abstract class RunCommandNeighborDiscovererBase : INeighborDiscoverer {
-    protected static string FindPathToCommand(string command, IEnumerable<string> paths) {}
-
-    protected RunCommandNeighborDiscovererBase(ILogger? logger) {}
-
-    public virtual ValueTask DiscoverAsync(CancellationToken cancellationToken) {}
-    public virtual ValueTask DiscoverAsync(IEnumerable<IPAddress> addresses, CancellationToken cancellationToken) {}
-    protected abstract bool GetCommandLineArguments(IEnumerable<IPAddress> addressesToDiscover, out string executable, out string arguments);
-    protected abstract bool GetCommandLineArguments(out string executable, out string arguments);
-  }
-
-  public readonly struct NeighborTableEntry :
+  public readonly struct AddressTableEntry :
+    IEquatable<AddressTableEntry>,
     IEquatable<IPAddress>,
     IEquatable<PhysicalAddress>
   {
-    public NeighborTableEntry(IPAddress ipAddress, PhysicalAddress? physicalAddress, bool isPermanent, NeighborTableEntryState state, int? interfaceIndex = null, string? interfaceName = null) {}
+    public static readonly AddressTableEntry Empty; // = "{IP=, MAC=(null), IsPermanent=False, State=None, Iface=}"
 
-    public IPAddress IPAddress { get; }
-    public int? InterfaceIndex { get; }
-    public string? InterfaceName { get; }
+    public static IEqualityComparer<AddressTableEntry> DefaultEqualityComparer { get; }
+    public static IEqualityComparer<AddressTableEntry> ExceptStateEqualityComparer { get; }
+
+    public AddressTableEntry(IPAddress ipAddress, PhysicalAddress? physicalAddress, bool isPermanent, AddressTableEntryState state, string? interfaceId) {}
+
+    public IPAddress? IPAddress { get; }
+    public string? InterfaceId { get; }
+    [MemberNotNullWhen(false, "IPAddress")]
+    public bool IsEmpty { [MemberNotNullWhen(false, "IPAddress")] get; }
     public bool IsPermanent { get; }
     public PhysicalAddress? PhysicalAddress { get; }
-    public NeighborTableEntryState State { get; }
+    public AddressTableEntryState State { get; }
 
+    public bool Equals(AddressTableEntry other) {}
     public bool Equals(IPAddress? other) {}
     public bool Equals(PhysicalAddress? other) {}
+    public override bool Equals(object? obj) {}
+    public override int GetHashCode() {}
+    public override string ToString() {}
+  }
+}
+
+namespace Smdn.Net.NetworkScanning {
+  public interface INetworkScanner : IDisposable {
+    ValueTask ScanAsync(CancellationToken cancellationToken);
+    ValueTask ScanAsync(IEnumerable<IPAddress> addresses, CancellationToken cancellationToken);
+  }
+
+  public sealed class ArpScanCommandNetworkScanner : CommandNetworkScanner {
+    public static bool IsSupported { get; }
+
+    public ArpScanCommandNetworkScanner(IPNetworkProfile? networkProfile, IServiceProvider? serviceProvider) {}
+
+    protected override bool GetCommandLineArguments(IEnumerable<IPAddress> addressesToScan, out string executable, out string arguments) {}
+    protected override bool GetCommandLineArguments(out string executable, out string arguments) {}
+  }
+
+  public abstract class CommandNetworkScanner : INetworkScanner {
+    public interface IProcessFactory {
+      Process CreateProcess(ProcessStartInfo processStartInfo);
+    }
+
+    protected readonly struct Command {
+      public Command(string name, string? executablePath) {}
+
+      public bool IsAvailable { get; }
+      public string Name { get; }
+
+      public string GetExecutablePathOrThrow() {}
+    }
+
+    protected static IReadOnlyCollection<string> DefaultCommandPaths { get; }
+
+    protected static CommandNetworkScanner.Command FindCommand(string command, IEnumerable<string> paths) {}
+
+    protected CommandNetworkScanner(ILogger? logger, IServiceProvider? serviceProvider) {}
+
+    protected virtual void Dispose(bool disposing) {}
+    public void Dispose() {}
+    protected abstract bool GetCommandLineArguments(IEnumerable<IPAddress> addressesToScan, out string executable, out string? arguments);
+    protected abstract bool GetCommandLineArguments(out string executable, out string? arguments);
+    public virtual ValueTask ScanAsync(CancellationToken cancellationToken = default) {}
+    public virtual ValueTask ScanAsync(IEnumerable<IPAddress> addresses, CancellationToken cancellationToken = default) {}
+  }
+
+  public sealed class IpHlpApiNetworkScanner : INetworkScanner {
+    public IpHlpApiNetworkScanner(IPNetworkProfile networkProfile, IServiceProvider? serviceProvider = null) {}
+
+    public ValueTask ScanAsync(CancellationToken cancellationToken = default) {}
+    public async ValueTask ScanAsync(IEnumerable<IPAddress> addresses, CancellationToken cancellationToken = default) {}
+    void IDisposable.Dispose() {}
+  }
+
+  public sealed class NmapCommandNetworkScanner : CommandNetworkScanner {
+    public static bool IsSupported { get; }
+
+    public NmapCommandNetworkScanner(IPNetworkProfile networkProfile, IServiceProvider? serviceProvider) {}
+
+    protected override bool GetCommandLineArguments(IEnumerable<IPAddress> addressesToScan, out string executable, out string arguments) {}
+    protected override bool GetCommandLineArguments(out string executable, out string arguments) {}
+  }
+
+  public sealed class PingNetworkScanner : INetworkScanner {
+    public PingNetworkScanner(IPNetworkProfile networkProfile, IServiceProvider? serviceProvider = null) {}
+
+    public void Dispose() {}
+    public ValueTask ScanAsync(CancellationToken cancellationToken = default) {}
+    public ValueTask ScanAsync(IEnumerable<IPAddress> addresses, CancellationToken cancellationToken = default) {}
   }
 }
 // API list generated by Smdn.Reflection.ReverseGenerating.ListApi.MSBuild.Tasks v1.2.1.0.

--- a/doc/api-list/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution-netstandard2.0.apilist.cs
+++ b/doc/api-list/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution-netstandard2.0.apilist.cs
@@ -1,16 +1,16 @@
-// Smdn.Net.AddressResolution.dll (Smdn.Net.AddressResolution-1.0.0-preview6)
+// Smdn.Net.AddressResolution.dll (Smdn.Net.AddressResolution-1.0.0-rc1)
 //   Name: Smdn.Net.AddressResolution
 //   AssemblyVersion: 1.0.0.0
-//   InformationalVersion: 1.0.0-preview6+867630e3d8768ccca99d991e9c0c1cca62c64c76
+//   InformationalVersion: 1.0.0-rc1+54f2767c7798db11d76ae3836009b55f701af69f
 //   TargetFramework: .NETStandard,Version=v2.0
 //   Configuration: Release
 //   Referenced assemblies:
 //     Microsoft.Bcl.AsyncInterfaces, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
+//     Microsoft.Bcl.HashCode, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
 //     Microsoft.Extensions.DependencyInjection.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Microsoft.Extensions.Logging.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
 //     System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
-//     Vanara.Core, Version=3.4.13.0, Culture=neutral, PublicKeyToken=c37e4080322237fa
 //     Vanara.PInvoke.IpHlpApi, Version=3.4.13.0, Culture=neutral, PublicKeyToken=c37e4080322237fa
 //     Vanara.PInvoke.Shared, Version=3.4.13.0, Culture=neutral, PublicKeyToken=c37e4080322237fa
 //     Vanara.PInvoke.Ws2_32, Version=3.4.13.0, Culture=neutral, PublicKeyToken=c37e4080322237fa
@@ -19,6 +19,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Runtime.CompilerServices;
@@ -27,7 +28,8 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Smdn.Net;
 using Smdn.Net.AddressResolution;
-using Smdn.Net.NeighborDiscovery;
+using Smdn.Net.AddressTables;
+using Smdn.Net.NetworkScanning;
 
 namespace Smdn.Net {
   public abstract class IPNetworkProfile {
@@ -36,7 +38,7 @@ namespace Smdn.Net {
     public static IPNetworkProfile Create(IPAddress baseAddress, IPAddress subnetMask, NetworkInterface? networkInterface = null) {}
     public static IPNetworkProfile Create(IPAddress baseAddress, int prefixLength, NetworkInterface? networkInterface = null) {}
     public static IPNetworkProfile Create(NetworkInterface networkInterface) {}
-    public static IPNetworkProfile Create(Predicate<NetworkInterface> predicate) {}
+    public static IPNetworkProfile Create(Predicate<NetworkInterface> predicateForNetworkInterface) {}
 
     protected IPNetworkProfile(NetworkInterface? networkInterface) {}
 
@@ -51,27 +53,32 @@ namespace Smdn.Net {
 }
 
 namespace Smdn.Net.AddressResolution {
-  public interface IAddressResolver<TAddress, TResolvedAddress> {
+  public interface IAddressResolver<TAddress, TResolvedAddress> where TAddress : notnull where TResolvedAddress : notnull {
     void Invalidate(TAddress address);
-    ValueTask<TResolvedAddress> ResolveAsync(TAddress address, CancellationToken cancellationToken);
+    ValueTask<TResolvedAddress?> ResolveAsync(TAddress address, CancellationToken cancellationToken);
   }
 
   public class MacAddressResolver : MacAddressResolverBase {
-    protected MacAddressResolver(INeighborTable neighborTable, INeighborDiscoverer neighborDiscoverer, TimeSpan neighborDiscoveryInterval, ILogger? logger) {}
-    public MacAddressResolver(INeighborTable? neighborTable = null, INeighborDiscoverer? neighborDiscoverer = null, int neighborDiscoveryIntervalMilliseconds = -1, IServiceProvider? serviceProvider = null) {}
+    protected MacAddressResolver(IAddressTable addressTable, bool shouldDisposeAddressTable, INetworkScanner? networkScanner, bool shouldDisposeNetworkScanner, NetworkInterface? networkInterface, int maxParallelCountForRefreshInvalidatedCache, ILogger? logger) {}
+    public MacAddressResolver() {}
+    public MacAddressResolver(IAddressTable? addressTable, INetworkScanner? networkScanner, bool shouldDisposeAddressTable = false, bool shouldDisposeNetworkScanner = false, NetworkInterface? networkInterface = null, int maxParallelCountForRefreshInvalidatedCache = 3, IServiceProvider? serviceProvider = null) {}
     public MacAddressResolver(IPNetworkProfile? networkProfile, IServiceProvider? serviceProvider = null) {}
-    public MacAddressResolver(IPNetworkProfile? networkProfile, TimeSpan neighborDiscoveryInterval, IServiceProvider? serviceProvider = null) {}
-    public MacAddressResolver(TimeSpan neighborDiscoveryInterval, INeighborTable? neighborTable = null, INeighborDiscoverer? neighborDiscoverer = null, IServiceProvider? serviceProvider = null) {}
 
+    public bool CanPerformNetworkScan { get; }
     public override bool HasInvalidated { get; }
+    public TimeSpan NetworkScanInterval { get; set; }
+    public TimeSpan NetworkScanMinInterval { get; set; }
 
     protected override void Dispose(bool disposing) {}
+    public IAsyncEnumerable<AddressTableEntry> EnumerateAddressTableEntriesAsync(CancellationToken cancellationToken = default) {}
+    public IAsyncEnumerable<AddressTableEntry> EnumerateAddressTableEntriesAsync(Predicate<AddressTableEntry> predicate, CancellationToken cancellationToken = default) {}
     protected override void InvalidateCore(IPAddress ipAddress) {}
     protected override void InvalidateCore(PhysicalAddress macAddress) {}
     protected override ValueTask RefreshCacheAsyncCore(CancellationToken cancellationToken = default) {}
     protected override ValueTask RefreshInvalidatedCacheAsyncCore(CancellationToken cancellationToken = default) {}
     protected override async ValueTask<PhysicalAddress?> ResolveIPAddressToMacAddressAsyncCore(IPAddress ipAddress, CancellationToken cancellationToken) {}
     protected override async ValueTask<IPAddress?> ResolveMacAddressToIPAddressAsyncCore(PhysicalAddress macAddress, CancellationToken cancellationToken) {}
+    protected virtual async ValueTask<AddressTableEntry> SelectAddressTableEntryAsync(Predicate<AddressTableEntry> predicate, CancellationToken cancellationToken) {}
   }
 
   public abstract class MacAddressResolverBase :
@@ -109,17 +116,12 @@ namespace Smdn.Net.AddressResolution {
   }
 }
 
-namespace Smdn.Net.NeighborDiscovery {
-  public interface INeighborDiscoverer {
-    ValueTask DiscoverAsync(CancellationToken cancellationToken);
-    ValueTask DiscoverAsync(IEnumerable<IPAddress> addresses, CancellationToken cancellationToken);
+namespace Smdn.Net.AddressTables {
+  public interface IAddressTable : IDisposable {
+    IAsyncEnumerable<AddressTableEntry> EnumerateEntriesAsync(CancellationToken cancellationToken);
   }
 
-  public interface INeighborTable {
-    IAsyncEnumerable<NeighborTableEntry> EnumerateEntriesAsync(CancellationToken cancellationToken);
-  }
-
-  public enum NeighborTableEntryState : int {
+  public enum AddressTableEntryState : int {
     Delay = 4,
     Incomplete = 1,
     None = 0,
@@ -128,82 +130,120 @@ namespace Smdn.Net.NeighborDiscovery {
     Stale = 3,
   }
 
-  public sealed class ArpScanCommandNeighborDiscoverer : RunCommandNeighborDiscovererBase {
+  public sealed class IpHlpApiAddressTable : IAddressTable {
     public static bool IsSupported { get; }
 
-    public ArpScanCommandNeighborDiscoverer(IPNetworkProfile? networkProfile, IServiceProvider? serviceProvider) {}
+    public IpHlpApiAddressTable(IServiceProvider? serviceProvider = null) {}
 
-    protected override bool GetCommandLineArguments(IEnumerable<IPAddress> addressesToDiscover, out string executable, out string arguments) {}
-    protected override bool GetCommandLineArguments(out string executable, out string arguments) {}
+    [AsyncIteratorStateMachine(typeof(IpHlpApiAddressTable.<EnumerateEntriesAsync>d__6))]
+    public IAsyncEnumerable<AddressTableEntry> EnumerateEntriesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default) {}
+    void IDisposable.Dispose() {}
   }
 
-  public sealed class IpHlpApiNeighborDiscoverer : INeighborDiscoverer {
-    public IpHlpApiNeighborDiscoverer(IPNetworkProfile networkProfile, ILogger? logger = null) {}
-
-    public ValueTask DiscoverAsync(CancellationToken cancellationToken = default) {}
-    public async ValueTask DiscoverAsync(IEnumerable<IPAddress> addresses, CancellationToken cancellationToken = default) {}
-  }
-
-  public sealed class IpHlpApiNeighborTable : INeighborTable {
+  public sealed class ProcfsArpAddressTable : IAddressTable {
     public static bool IsSupported { get; }
 
-    public IpHlpApiNeighborTable(IServiceProvider? serviceProvider = null) {}
+    public ProcfsArpAddressTable(IServiceProvider? serviceProvider = null) {}
 
-    [AsyncIteratorStateMachine(typeof(IpHlpApiNeighborTable.<EnumerateEntriesAsync>d__5))]
-    public IAsyncEnumerable<NeighborTableEntry> EnumerateEntriesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default) {}
+    [AsyncIteratorStateMachine(typeof(ProcfsArpAddressTable.<EnumerateEntriesAsync>d__7))]
+    public IAsyncEnumerable<AddressTableEntry> EnumerateEntriesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default) {}
+    void IDisposable.Dispose() {}
   }
 
-  public sealed class NmapCommandNeighborDiscoverer : RunCommandNeighborDiscovererBase {
-    public static bool IsSupported { get; }
-
-    public NmapCommandNeighborDiscoverer(IPNetworkProfile networkProfile, IServiceProvider? serviceProvider) {}
-
-    protected override bool GetCommandLineArguments(IEnumerable<IPAddress> addressesToDiscover, out string executable, out string arguments) {}
-    protected override bool GetCommandLineArguments(out string executable, out string arguments) {}
-  }
-
-  public sealed class NullNeighborDiscoverer : INeighborDiscoverer {
-    public static readonly NullNeighborDiscoverer Instance; // = "Smdn.Net.NeighborDiscovery.NullNeighborDiscoverer"
-
-    public ValueTask DiscoverAsync(CancellationToken cancellationToken) {}
-    public ValueTask DiscoverAsync(IEnumerable<IPAddress> addresses, CancellationToken cancellationToken) {}
-  }
-
-  public sealed class ProcfsArpNeighborTable : INeighborTable {
-    public static bool IsSupported { get; }
-
-    public ProcfsArpNeighborTable(IServiceProvider? serviceProvider = null) {}
-
-    [AsyncIteratorStateMachine(typeof(ProcfsArpNeighborTable.<EnumerateEntriesAsync>d__6))]
-    public IAsyncEnumerable<NeighborTableEntry> EnumerateEntriesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default) {}
-  }
-
-  public abstract class RunCommandNeighborDiscovererBase : INeighborDiscoverer {
-    protected static string FindPathToCommand(string command, IEnumerable<string> paths) {}
-
-    protected RunCommandNeighborDiscovererBase(ILogger? logger) {}
-
-    public virtual ValueTask DiscoverAsync(CancellationToken cancellationToken) {}
-    public virtual ValueTask DiscoverAsync(IEnumerable<IPAddress> addresses, CancellationToken cancellationToken) {}
-    protected abstract bool GetCommandLineArguments(IEnumerable<IPAddress> addressesToDiscover, out string executable, out string arguments);
-    protected abstract bool GetCommandLineArguments(out string executable, out string arguments);
-  }
-
-  public readonly struct NeighborTableEntry :
+  public readonly struct AddressTableEntry :
+    IEquatable<AddressTableEntry>,
     IEquatable<IPAddress>,
     IEquatable<PhysicalAddress>
   {
-    public NeighborTableEntry(IPAddress ipAddress, PhysicalAddress? physicalAddress, bool isPermanent, NeighborTableEntryState state, int? interfaceIndex = null, string? interfaceName = null) {}
+    public static readonly AddressTableEntry Empty; // = "{IP=, MAC=(null), IsPermanent=False, State=None, Iface=}"
 
-    public IPAddress IPAddress { get; }
-    public int? InterfaceIndex { get; }
-    public string? InterfaceName { get; }
+    public static IEqualityComparer<AddressTableEntry> DefaultEqualityComparer { get; }
+    public static IEqualityComparer<AddressTableEntry> ExceptStateEqualityComparer { get; }
+
+    public AddressTableEntry(IPAddress ipAddress, PhysicalAddress? physicalAddress, bool isPermanent, AddressTableEntryState state, string? interfaceId) {}
+
+    public IPAddress? IPAddress { get; }
+    public string? InterfaceId { get; }
+    public bool IsEmpty { get; }
     public bool IsPermanent { get; }
     public PhysicalAddress? PhysicalAddress { get; }
-    public NeighborTableEntryState State { get; }
+    public AddressTableEntryState State { get; }
 
+    public bool Equals(AddressTableEntry other) {}
     public bool Equals(IPAddress? other) {}
     public bool Equals(PhysicalAddress? other) {}
+    public override bool Equals(object? obj) {}
+    public override int GetHashCode() {}
+    public override string ToString() {}
+  }
+}
+
+namespace Smdn.Net.NetworkScanning {
+  public interface INetworkScanner : IDisposable {
+    ValueTask ScanAsync(CancellationToken cancellationToken);
+    ValueTask ScanAsync(IEnumerable<IPAddress> addresses, CancellationToken cancellationToken);
+  }
+
+  public sealed class ArpScanCommandNetworkScanner : CommandNetworkScanner {
+    public static bool IsSupported { get; }
+
+    public ArpScanCommandNetworkScanner(IPNetworkProfile? networkProfile, IServiceProvider? serviceProvider) {}
+
+    protected override bool GetCommandLineArguments(IEnumerable<IPAddress> addressesToScan, out string executable, out string arguments) {}
+    protected override bool GetCommandLineArguments(out string executable, out string arguments) {}
+  }
+
+  public abstract class CommandNetworkScanner : INetworkScanner {
+    public interface IProcessFactory {
+      Process CreateProcess(ProcessStartInfo processStartInfo);
+    }
+
+    protected readonly struct Command {
+      public Command(string name, string? executablePath) {}
+
+      public bool IsAvailable { get; }
+      public string Name { get; }
+
+      public string GetExecutablePathOrThrow() {}
+    }
+
+    protected static IReadOnlyCollection<string> DefaultCommandPaths { get; }
+
+    protected static CommandNetworkScanner.Command FindCommand(string command, IEnumerable<string> paths) {}
+
+    protected CommandNetworkScanner(ILogger? logger, IServiceProvider? serviceProvider) {}
+
+    protected virtual void Dispose(bool disposing) {}
+    public void Dispose() {}
+    protected abstract bool GetCommandLineArguments(IEnumerable<IPAddress> addressesToScan, out string executable, out string? arguments);
+    protected abstract bool GetCommandLineArguments(out string executable, out string? arguments);
+    public virtual ValueTask ScanAsync(CancellationToken cancellationToken = default) {}
+    public virtual ValueTask ScanAsync(IEnumerable<IPAddress> addresses, CancellationToken cancellationToken = default) {}
+  }
+
+  public sealed class IpHlpApiNetworkScanner : INetworkScanner {
+    public IpHlpApiNetworkScanner(IPNetworkProfile networkProfile, IServiceProvider? serviceProvider = null) {}
+
+    public ValueTask ScanAsync(CancellationToken cancellationToken = default) {}
+    public async ValueTask ScanAsync(IEnumerable<IPAddress> addresses, CancellationToken cancellationToken = default) {}
+    void IDisposable.Dispose() {}
+  }
+
+  public sealed class NmapCommandNetworkScanner : CommandNetworkScanner {
+    public static bool IsSupported { get; }
+
+    public NmapCommandNetworkScanner(IPNetworkProfile networkProfile, IServiceProvider? serviceProvider) {}
+
+    protected override bool GetCommandLineArguments(IEnumerable<IPAddress> addressesToScan, out string executable, out string arguments) {}
+    protected override bool GetCommandLineArguments(out string executable, out string arguments) {}
+  }
+
+  public sealed class PingNetworkScanner : INetworkScanner {
+    public PingNetworkScanner(IPNetworkProfile networkProfile, IServiceProvider? serviceProvider = null) {}
+
+    public void Dispose() {}
+    public ValueTask ScanAsync(CancellationToken cancellationToken = default) {}
+    public ValueTask ScanAsync(IEnumerable<IPAddress> addresses, CancellationToken cancellationToken = default) {}
   }
 }
 // API list generated by Smdn.Reflection.ReverseGenerating.ListApi.MSBuild.Tasks v1.2.1.0.

--- a/doc/api-list/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution-netstandard2.1.apilist.cs
@@ -1,13 +1,12 @@
-// Smdn.Net.AddressResolution.dll (Smdn.Net.AddressResolution-1.0.0-preview6)
+// Smdn.Net.AddressResolution.dll (Smdn.Net.AddressResolution-1.0.0-rc1)
 //   Name: Smdn.Net.AddressResolution
 //   AssemblyVersion: 1.0.0.0
-//   InformationalVersion: 1.0.0-preview6+867630e3d8768ccca99d991e9c0c1cca62c64c76
+//   InformationalVersion: 1.0.0-rc1+54f2767c7798db11d76ae3836009b55f701af69f
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 //   Referenced assemblies:
 //     Microsoft.Extensions.DependencyInjection.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Microsoft.Extensions.Logging.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
-//     Vanara.Core, Version=3.4.13.0, Culture=neutral, PublicKeyToken=c37e4080322237fa
 //     Vanara.PInvoke.IpHlpApi, Version=3.4.13.0, Culture=neutral, PublicKeyToken=c37e4080322237fa
 //     Vanara.PInvoke.Shared, Version=3.4.13.0, Culture=neutral, PublicKeyToken=c37e4080322237fa
 //     Vanara.PInvoke.Ws2_32, Version=3.4.13.0, Culture=neutral, PublicKeyToken=c37e4080322237fa
@@ -16,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Runtime.CompilerServices;
@@ -24,7 +24,8 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Smdn.Net;
 using Smdn.Net.AddressResolution;
-using Smdn.Net.NeighborDiscovery;
+using Smdn.Net.AddressTables;
+using Smdn.Net.NetworkScanning;
 
 namespace Smdn.Net {
   public abstract class IPNetworkProfile {
@@ -33,7 +34,7 @@ namespace Smdn.Net {
     public static IPNetworkProfile Create(IPAddress baseAddress, IPAddress subnetMask, NetworkInterface? networkInterface = null) {}
     public static IPNetworkProfile Create(IPAddress baseAddress, int prefixLength, NetworkInterface? networkInterface = null) {}
     public static IPNetworkProfile Create(NetworkInterface networkInterface) {}
-    public static IPNetworkProfile Create(Predicate<NetworkInterface> predicate) {}
+    public static IPNetworkProfile Create(Predicate<NetworkInterface> predicateForNetworkInterface) {}
 
     protected IPNetworkProfile(NetworkInterface? networkInterface) {}
 
@@ -48,27 +49,32 @@ namespace Smdn.Net {
 }
 
 namespace Smdn.Net.AddressResolution {
-  public interface IAddressResolver<TAddress, TResolvedAddress> {
+  public interface IAddressResolver<TAddress, TResolvedAddress> where TAddress : notnull where TResolvedAddress : notnull {
     void Invalidate(TAddress address);
-    ValueTask<TResolvedAddress> ResolveAsync(TAddress address, CancellationToken cancellationToken);
+    ValueTask<TResolvedAddress?> ResolveAsync(TAddress address, CancellationToken cancellationToken);
   }
 
   public class MacAddressResolver : MacAddressResolverBase {
-    protected MacAddressResolver(INeighborTable neighborTable, INeighborDiscoverer neighborDiscoverer, TimeSpan neighborDiscoveryInterval, ILogger? logger) {}
-    public MacAddressResolver(INeighborTable? neighborTable = null, INeighborDiscoverer? neighborDiscoverer = null, int neighborDiscoveryIntervalMilliseconds = -1, IServiceProvider? serviceProvider = null) {}
+    protected MacAddressResolver(IAddressTable addressTable, bool shouldDisposeAddressTable, INetworkScanner? networkScanner, bool shouldDisposeNetworkScanner, NetworkInterface? networkInterface, int maxParallelCountForRefreshInvalidatedCache, ILogger? logger) {}
+    public MacAddressResolver() {}
+    public MacAddressResolver(IAddressTable? addressTable, INetworkScanner? networkScanner, bool shouldDisposeAddressTable = false, bool shouldDisposeNetworkScanner = false, NetworkInterface? networkInterface = null, int maxParallelCountForRefreshInvalidatedCache = 3, IServiceProvider? serviceProvider = null) {}
     public MacAddressResolver(IPNetworkProfile? networkProfile, IServiceProvider? serviceProvider = null) {}
-    public MacAddressResolver(IPNetworkProfile? networkProfile, TimeSpan neighborDiscoveryInterval, IServiceProvider? serviceProvider = null) {}
-    public MacAddressResolver(TimeSpan neighborDiscoveryInterval, INeighborTable? neighborTable = null, INeighborDiscoverer? neighborDiscoverer = null, IServiceProvider? serviceProvider = null) {}
 
+    public bool CanPerformNetworkScan { get; }
     public override bool HasInvalidated { get; }
+    public TimeSpan NetworkScanInterval { get; set; }
+    public TimeSpan NetworkScanMinInterval { get; set; }
 
     protected override void Dispose(bool disposing) {}
+    public IAsyncEnumerable<AddressTableEntry> EnumerateAddressTableEntriesAsync(CancellationToken cancellationToken = default) {}
+    public IAsyncEnumerable<AddressTableEntry> EnumerateAddressTableEntriesAsync(Predicate<AddressTableEntry> predicate, CancellationToken cancellationToken = default) {}
     protected override void InvalidateCore(IPAddress ipAddress) {}
     protected override void InvalidateCore(PhysicalAddress macAddress) {}
     protected override ValueTask RefreshCacheAsyncCore(CancellationToken cancellationToken = default) {}
     protected override ValueTask RefreshInvalidatedCacheAsyncCore(CancellationToken cancellationToken = default) {}
     protected override async ValueTask<PhysicalAddress?> ResolveIPAddressToMacAddressAsyncCore(IPAddress ipAddress, CancellationToken cancellationToken) {}
     protected override async ValueTask<IPAddress?> ResolveMacAddressToIPAddressAsyncCore(PhysicalAddress macAddress, CancellationToken cancellationToken) {}
+    protected virtual async ValueTask<AddressTableEntry> SelectAddressTableEntryAsync(Predicate<AddressTableEntry> predicate, CancellationToken cancellationToken) {}
   }
 
   public abstract class MacAddressResolverBase :
@@ -106,17 +112,12 @@ namespace Smdn.Net.AddressResolution {
   }
 }
 
-namespace Smdn.Net.NeighborDiscovery {
-  public interface INeighborDiscoverer {
-    ValueTask DiscoverAsync(CancellationToken cancellationToken);
-    ValueTask DiscoverAsync(IEnumerable<IPAddress> addresses, CancellationToken cancellationToken);
+namespace Smdn.Net.AddressTables {
+  public interface IAddressTable : IDisposable {
+    IAsyncEnumerable<AddressTableEntry> EnumerateEntriesAsync(CancellationToken cancellationToken);
   }
 
-  public interface INeighborTable {
-    IAsyncEnumerable<NeighborTableEntry> EnumerateEntriesAsync(CancellationToken cancellationToken);
-  }
-
-  public enum NeighborTableEntryState : int {
+  public enum AddressTableEntryState : int {
     Delay = 4,
     Incomplete = 1,
     None = 0,
@@ -125,82 +126,120 @@ namespace Smdn.Net.NeighborDiscovery {
     Stale = 3,
   }
 
-  public sealed class ArpScanCommandNeighborDiscoverer : RunCommandNeighborDiscovererBase {
+  public sealed class IpHlpApiAddressTable : IAddressTable {
     public static bool IsSupported { get; }
 
-    public ArpScanCommandNeighborDiscoverer(IPNetworkProfile? networkProfile, IServiceProvider? serviceProvider) {}
+    public IpHlpApiAddressTable(IServiceProvider? serviceProvider = null) {}
 
-    protected override bool GetCommandLineArguments(IEnumerable<IPAddress> addressesToDiscover, out string executable, out string arguments) {}
-    protected override bool GetCommandLineArguments(out string executable, out string arguments) {}
+    [AsyncIteratorStateMachine(typeof(IpHlpApiAddressTable.<EnumerateEntriesAsync>d__6))]
+    public IAsyncEnumerable<AddressTableEntry> EnumerateEntriesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default) {}
+    void IDisposable.Dispose() {}
   }
 
-  public sealed class IpHlpApiNeighborDiscoverer : INeighborDiscoverer {
-    public IpHlpApiNeighborDiscoverer(IPNetworkProfile networkProfile, ILogger? logger = null) {}
-
-    public ValueTask DiscoverAsync(CancellationToken cancellationToken = default) {}
-    public async ValueTask DiscoverAsync(IEnumerable<IPAddress> addresses, CancellationToken cancellationToken = default) {}
-  }
-
-  public sealed class IpHlpApiNeighborTable : INeighborTable {
+  public sealed class ProcfsArpAddressTable : IAddressTable {
     public static bool IsSupported { get; }
 
-    public IpHlpApiNeighborTable(IServiceProvider? serviceProvider = null) {}
+    public ProcfsArpAddressTable(IServiceProvider? serviceProvider = null) {}
 
-    [AsyncIteratorStateMachine(typeof(IpHlpApiNeighborTable.<EnumerateEntriesAsync>d__5))]
-    public IAsyncEnumerable<NeighborTableEntry> EnumerateEntriesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default) {}
+    [AsyncIteratorStateMachine(typeof(ProcfsArpAddressTable.<EnumerateEntriesAsync>d__7))]
+    public IAsyncEnumerable<AddressTableEntry> EnumerateEntriesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default) {}
+    void IDisposable.Dispose() {}
   }
 
-  public sealed class NmapCommandNeighborDiscoverer : RunCommandNeighborDiscovererBase {
-    public static bool IsSupported { get; }
-
-    public NmapCommandNeighborDiscoverer(IPNetworkProfile networkProfile, IServiceProvider? serviceProvider) {}
-
-    protected override bool GetCommandLineArguments(IEnumerable<IPAddress> addressesToDiscover, out string executable, out string arguments) {}
-    protected override bool GetCommandLineArguments(out string executable, out string arguments) {}
-  }
-
-  public sealed class NullNeighborDiscoverer : INeighborDiscoverer {
-    public static readonly NullNeighborDiscoverer Instance; // = "Smdn.Net.NeighborDiscovery.NullNeighborDiscoverer"
-
-    public ValueTask DiscoverAsync(CancellationToken cancellationToken) {}
-    public ValueTask DiscoverAsync(IEnumerable<IPAddress> addresses, CancellationToken cancellationToken) {}
-  }
-
-  public sealed class ProcfsArpNeighborTable : INeighborTable {
-    public static bool IsSupported { get; }
-
-    public ProcfsArpNeighborTable(IServiceProvider? serviceProvider = null) {}
-
-    [AsyncIteratorStateMachine(typeof(ProcfsArpNeighborTable.<EnumerateEntriesAsync>d__6))]
-    public IAsyncEnumerable<NeighborTableEntry> EnumerateEntriesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default) {}
-  }
-
-  public abstract class RunCommandNeighborDiscovererBase : INeighborDiscoverer {
-    protected static string FindPathToCommand(string command, IEnumerable<string> paths) {}
-
-    protected RunCommandNeighborDiscovererBase(ILogger? logger) {}
-
-    public virtual ValueTask DiscoverAsync(CancellationToken cancellationToken) {}
-    public virtual ValueTask DiscoverAsync(IEnumerable<IPAddress> addresses, CancellationToken cancellationToken) {}
-    protected abstract bool GetCommandLineArguments(IEnumerable<IPAddress> addressesToDiscover, out string executable, out string arguments);
-    protected abstract bool GetCommandLineArguments(out string executable, out string arguments);
-  }
-
-  public readonly struct NeighborTableEntry :
+  public readonly struct AddressTableEntry :
+    IEquatable<AddressTableEntry>,
     IEquatable<IPAddress>,
     IEquatable<PhysicalAddress>
   {
-    public NeighborTableEntry(IPAddress ipAddress, PhysicalAddress? physicalAddress, bool isPermanent, NeighborTableEntryState state, int? interfaceIndex = null, string? interfaceName = null) {}
+    public static readonly AddressTableEntry Empty; // = "{IP=, MAC=(null), IsPermanent=False, State=None, Iface=}"
 
-    public IPAddress IPAddress { get; }
-    public int? InterfaceIndex { get; }
-    public string? InterfaceName { get; }
+    public static IEqualityComparer<AddressTableEntry> DefaultEqualityComparer { get; }
+    public static IEqualityComparer<AddressTableEntry> ExceptStateEqualityComparer { get; }
+
+    public AddressTableEntry(IPAddress ipAddress, PhysicalAddress? physicalAddress, bool isPermanent, AddressTableEntryState state, string? interfaceId) {}
+
+    public IPAddress? IPAddress { get; }
+    public string? InterfaceId { get; }
+    public bool IsEmpty { get; }
     public bool IsPermanent { get; }
     public PhysicalAddress? PhysicalAddress { get; }
-    public NeighborTableEntryState State { get; }
+    public AddressTableEntryState State { get; }
 
+    public bool Equals(AddressTableEntry other) {}
     public bool Equals(IPAddress? other) {}
     public bool Equals(PhysicalAddress? other) {}
+    public override bool Equals(object? obj) {}
+    public override int GetHashCode() {}
+    public override string ToString() {}
+  }
+}
+
+namespace Smdn.Net.NetworkScanning {
+  public interface INetworkScanner : IDisposable {
+    ValueTask ScanAsync(CancellationToken cancellationToken);
+    ValueTask ScanAsync(IEnumerable<IPAddress> addresses, CancellationToken cancellationToken);
+  }
+
+  public sealed class ArpScanCommandNetworkScanner : CommandNetworkScanner {
+    public static bool IsSupported { get; }
+
+    public ArpScanCommandNetworkScanner(IPNetworkProfile? networkProfile, IServiceProvider? serviceProvider) {}
+
+    protected override bool GetCommandLineArguments(IEnumerable<IPAddress> addressesToScan, out string executable, out string arguments) {}
+    protected override bool GetCommandLineArguments(out string executable, out string arguments) {}
+  }
+
+  public abstract class CommandNetworkScanner : INetworkScanner {
+    public interface IProcessFactory {
+      Process CreateProcess(ProcessStartInfo processStartInfo);
+    }
+
+    protected readonly struct Command {
+      public Command(string name, string? executablePath) {}
+
+      public bool IsAvailable { get; }
+      public string Name { get; }
+
+      public string GetExecutablePathOrThrow() {}
+    }
+
+    protected static IReadOnlyCollection<string> DefaultCommandPaths { get; }
+
+    protected static CommandNetworkScanner.Command FindCommand(string command, IEnumerable<string> paths) {}
+
+    protected CommandNetworkScanner(ILogger? logger, IServiceProvider? serviceProvider) {}
+
+    protected virtual void Dispose(bool disposing) {}
+    public void Dispose() {}
+    protected abstract bool GetCommandLineArguments(IEnumerable<IPAddress> addressesToScan, out string executable, out string? arguments);
+    protected abstract bool GetCommandLineArguments(out string executable, out string? arguments);
+    public virtual ValueTask ScanAsync(CancellationToken cancellationToken = default) {}
+    public virtual ValueTask ScanAsync(IEnumerable<IPAddress> addresses, CancellationToken cancellationToken = default) {}
+  }
+
+  public sealed class IpHlpApiNetworkScanner : INetworkScanner {
+    public IpHlpApiNetworkScanner(IPNetworkProfile networkProfile, IServiceProvider? serviceProvider = null) {}
+
+    public ValueTask ScanAsync(CancellationToken cancellationToken = default) {}
+    public async ValueTask ScanAsync(IEnumerable<IPAddress> addresses, CancellationToken cancellationToken = default) {}
+    void IDisposable.Dispose() {}
+  }
+
+  public sealed class NmapCommandNetworkScanner : CommandNetworkScanner {
+    public static bool IsSupported { get; }
+
+    public NmapCommandNetworkScanner(IPNetworkProfile networkProfile, IServiceProvider? serviceProvider) {}
+
+    protected override bool GetCommandLineArguments(IEnumerable<IPAddress> addressesToScan, out string executable, out string arguments) {}
+    protected override bool GetCommandLineArguments(out string executable, out string arguments) {}
+  }
+
+  public sealed class PingNetworkScanner : INetworkScanner {
+    public PingNetworkScanner(IPNetworkProfile networkProfile, IServiceProvider? serviceProvider = null) {}
+
+    public void Dispose() {}
+    public ValueTask ScanAsync(CancellationToken cancellationToken = default) {}
+    public ValueTask ScanAsync(IEnumerable<IPAddress> addresses, CancellationToken cancellationToken = default) {}
   }
 }
 // API list generated by Smdn.Reflection.ReverseGenerating.ListApi.MSBuild.Tasks v1.2.1.0.


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #9](https://github.com/smdn/Smdn.Net.AddressResolution/actions/runs/4694780048).

# Release target
- package_target_tag: `new-release/main/Smdn.Net.AddressResolution-1.0.0-rc1`
- package_prevver_ref: `releases/Smdn.Net.AddressResolution-1.0.0-preview6`
- package_prevver_tag: `releases/Smdn.Net.AddressResolution-1.0.0-preview6`
- package_id: `Smdn.Net.AddressResolution`
- package_id_with_version: `Smdn.Net.AddressResolution-1.0.0-rc1`
- package_version: `1.0.0-rc1`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Net.AddressResolution-1.0.0-rc1-1681429228`
- release_tag: `releases/Smdn.Net.AddressResolution-1.0.0-rc1`
- release_prerelease: `True` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/b797d9bfcea6798ed7f96b5aa84c7c30`](https://gist.github.com/smdn/b797d9bfcea6798ed7f96b5aa84c7c30)
- artifact_name_nupkg: `Smdn.Net.AddressResolution.1.0.0-rc1.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec diff
```diff
--- Smdn.Net.AddressResolution.latest.nuspec
+++ Smdn.Net.AddressResolution.1.0.0-rc1.nuspec
@@ -1,40 +1,49 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Smdn.Net.AddressResolution</id>
-    <version>1.0.0-preview6</version>
+    <version>1.0.0-rc1</version>
     <title>Smdn.Net.AddressResolution</title>
     <authors>smdn</authors>
     <license type="expression">MIT</license>
     <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <icon>Smdn.Net.AddressResolution.png</icon>
     <readme>README.md</readme>
     <projectUrl>https://github.com/smdn/Smdn.Net.AddressResolution</projectUrl>
     <description>A network address resolution library for .NET. This library provides interfaces for resolving between IP addresses and MAC addresses, also provides implementations of address resolution using the ARP table provided by each platform.</description>
     <copyright>Copyright © 2022 smdn</copyright>
-    <tags>smdn.jp ARP ip-address mac-address hardware-address address-lookup address-resolution</tags>
-    <repository type="git" url="https://github.com/smdn/Smdn.Net.AddressResolution" branch="main" commit="867630e3d8768ccca99d991e9c0c1cca62c64c76" />
+    <tags>smdn.jp ARP arp-scan arp-table ip-address mac-address hardware-address address-lookup address-resolution</tags>
+    <repository type="git" url="https://github.com/smdn/Smdn.Net.AddressResolution" commit="54f2767c7798db11d76ae3836009b55f701af69f" />
     <dependencies>
       <group targetFramework="net6.0">
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Vanara.PInvoke.IpHlpApi" version="3.4.13" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="net7.0">
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Vanara.PInvoke.IpHlpApi" version="3.4.13" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.0">
+        <dependency id="Microsoft.Bcl.HashCode" version="1.0.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Vanara.PInvoke.IpHlpApi" version="3.4.13" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.1">
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Vanara.PInvoke.IpHlpApi" version="3.4.13" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>
+  <files>
+    <file src="/home/runner/work/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution/src/Smdn.Net.AddressResolution/bin/Release/net6.0/Smdn.Net.AddressResolution.dll" target="lib/net6.0/Smdn.Net.AddressResolution.dll" />
+    <file src="/home/runner/work/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution/src/Smdn.Net.AddressResolution/bin/Release/net7.0/Smdn.Net.AddressResolution.dll" target="lib/net7.0/Smdn.Net.AddressResolution.dll" />
+    <file src="/home/runner/work/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution/src/Smdn.Net.AddressResolution/bin/Release/netstandard2.0/Smdn.Net.AddressResolution.dll" target="lib/netstandard2.0/Smdn.Net.AddressResolution.dll" />
+    <file src="/home/runner/work/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution/src/Smdn.Net.AddressResolution/bin/Release/netstandard2.1/Smdn.Net.AddressResolution.dll" target="lib/netstandard2.1/Smdn.Net.AddressResolution.dll" />
+    <file src="/home/runner/work/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution/.nuget/packages/smdn.msbuild.projectassets.common/1.3.5/project/images/package-icon.png" target="Smdn.Net.AddressResolution.png" />
+    <file src="/home/runner/work/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution/src/Smdn.Net.AddressResolution/bin/Release/README.md" target="README.md" />
+  </files>
 </package>
\ No newline at end of file
```

