### PR TITLE
Release main/Smdn.Net.AddressResolution-1.0.0-rc2

### DIFF
--- a/doc/api-list/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution-net6.0.apilist.cs
+++ b/doc/api-list/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution-net6.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.AddressResolution.dll (Smdn.Net.AddressResolution-1.0.0-rc1)
+// Smdn.Net.AddressResolution.dll (Smdn.Net.AddressResolution-1.0.0-rc2)
 //   Name: Smdn.Net.AddressResolution
 //   AssemblyVersion: 1.0.0.0
-//   InformationalVersion: 1.0.0-rc1+54f2767c7798db11d76ae3836009b55f701af69f
+//   InformationalVersion: 1.0.0-rc2+3ee5c5d35420506d56f36dcd2bf148727d37aa11
 //   TargetFramework: .NETCoreApp,Version=v6.0
 //   Configuration: Release
 //   Referenced assemblies:
@@ -69,9 +69,9 @@ namespace Smdn.Net.AddressResolution {
   }
 
   public class MacAddressResolver : MacAddressResolverBase {
-    protected MacAddressResolver(IAddressTable addressTable, bool shouldDisposeAddressTable, INetworkScanner? networkScanner, bool shouldDisposeNetworkScanner, NetworkInterface? networkInterface, int maxParallelCountForRefreshInvalidatedCache, ILogger? logger) {}
+    protected MacAddressResolver(IAddressTable addressTable, bool shouldDisposeAddressTable, INetworkScanner? networkScanner, bool shouldDisposeNetworkScanner, NetworkInterface? networkInterface, int maxParallelCountForRefreshInvalidatedAddresses, ILogger? logger) {}
     public MacAddressResolver() {}
-    public MacAddressResolver(IAddressTable? addressTable, INetworkScanner? networkScanner, bool shouldDisposeAddressTable = false, bool shouldDisposeNetworkScanner = false, NetworkInterface? networkInterface = null, int maxParallelCountForRefreshInvalidatedCache = 3, IServiceProvider? serviceProvider = null) {}
+    public MacAddressResolver(IAddressTable? addressTable, INetworkScanner? networkScanner, bool shouldDisposeAddressTable = false, bool shouldDisposeNetworkScanner = false, NetworkInterface? networkInterface = null, int maxParallelCountForRefreshInvalidatedAddresses = 3, IServiceProvider? serviceProvider = null) {}
     public MacAddressResolver(IPNetworkProfile? networkProfile, IServiceProvider? serviceProvider = null) {}
 
     public bool CanPerformNetworkScan { get; }
@@ -84,8 +84,8 @@ namespace Smdn.Net.AddressResolution {
     public IAsyncEnumerable<AddressTableEntry> EnumerateAddressTableEntriesAsync(Predicate<AddressTableEntry> predicate, CancellationToken cancellationToken = default) {}
     protected override void InvalidateCore(IPAddress ipAddress) {}
     protected override void InvalidateCore(PhysicalAddress macAddress) {}
-    protected override ValueTask RefreshCacheAsyncCore(CancellationToken cancellationToken = default) {}
-    protected override ValueTask RefreshInvalidatedCacheAsyncCore(CancellationToken cancellationToken = default) {}
+    protected override ValueTask RefreshAddressTableAsyncCore(CancellationToken cancellationToken = default) {}
+    protected override ValueTask RefreshInvalidatedAddressesAsyncCore(CancellationToken cancellationToken = default) {}
     protected override async ValueTask<PhysicalAddress?> ResolveIPAddressToMacAddressAsyncCore(IPAddress ipAddress, CancellationToken cancellationToken) {}
     protected override async ValueTask<IPAddress?> ResolveMacAddressToIPAddressAsyncCore(PhysicalAddress macAddress, CancellationToken cancellationToken) {}
     protected virtual async ValueTask<AddressTableEntry> SelectAddressTableEntryAsync(Predicate<AddressTableEntry> predicate, CancellationToken cancellationToken) {}
@@ -110,10 +110,10 @@ namespace Smdn.Net.AddressResolution {
     public void Invalidate(PhysicalAddress macAddress) {}
     protected abstract void InvalidateCore(IPAddress ipAddress);
     protected abstract void InvalidateCore(PhysicalAddress macAddress);
-    public ValueTask RefreshCacheAsync(CancellationToken cancellationToken = default) {}
-    protected virtual ValueTask RefreshCacheAsyncCore(CancellationToken cancellationToken) {}
-    public ValueTask RefreshInvalidatedCacheAsync(CancellationToken cancellationToken = default) {}
-    protected virtual ValueTask RefreshInvalidatedCacheAsyncCore(CancellationToken cancellationToken) {}
+    public ValueTask RefreshAddressTableAsync(CancellationToken cancellationToken = default) {}
+    protected virtual ValueTask RefreshAddressTableAsyncCore(CancellationToken cancellationToken) {}
+    public ValueTask RefreshInvalidatedAddressesAsync(CancellationToken cancellationToken = default) {}
+    protected virtual ValueTask RefreshInvalidatedAddressesAsyncCore(CancellationToken cancellationToken) {}
     public ValueTask<PhysicalAddress?> ResolveIPAddressToMacAddressAsync(IPAddress ipAddress, CancellationToken cancellationToken = default) {}
     protected abstract ValueTask<PhysicalAddress?> ResolveIPAddressToMacAddressAsyncCore(IPAddress ipAddress, CancellationToken cancellationToken);
     public ValueTask<IPAddress?> ResolveMacAddressToIPAddressAsync(PhysicalAddress macAddress, CancellationToken cancellationToken = default) {}
@@ -140,24 +140,38 @@ namespace Smdn.Net.AddressTables {
     Stale = 3,
   }
 
-  public sealed class IpHlpApiAddressTable : IAddressTable {
+  public abstract class AddressTable : IAddressTable {
+    public static IAddressTable Null { get; }
+
+    public static IAddressTable Create(IServiceProvider? serviceProvider = null) {}
+
+    protected AddressTable(ILogger? logger = null) {}
+
+    protected ILogger? Logger { get; }
+
+    protected virtual void Dispose(bool disposing) {}
+    public void Dispose() {}
+    public IAsyncEnumerable<AddressTableEntry> EnumerateEntriesAsync(CancellationToken cancellationToken = default) {}
+    protected abstract IAsyncEnumerable<AddressTableEntry> EnumerateEntriesAsyncCore(CancellationToken cancellationToken);
+    protected void ThrowIfDisposed() {}
+  }
+
+  public sealed class IpHlpApiAddressTable : AddressTable {
     public static bool IsSupported { get; }
 
     public IpHlpApiAddressTable(IServiceProvider? serviceProvider = null) {}
 
-    [AsyncIteratorStateMachine(typeof(IpHlpApiAddressTable.<EnumerateEntriesAsync>d__6))]
-    public IAsyncEnumerable<AddressTableEntry> EnumerateEntriesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default) {}
-    void IDisposable.Dispose() {}
+    [AsyncIteratorStateMachine(typeof(IpHlpApiAddressTable.<EnumerateEntriesAsyncCore>d__4))]
+    protected override IAsyncEnumerable<AddressTableEntry> EnumerateEntriesAsyncCore([EnumeratorCancellation] CancellationToken cancellationToken) {}
   }
 
-  public sealed class ProcfsArpAddressTable : IAddressTable {
+  public sealed class ProcfsArpAddressTable : AddressTable {
     public static bool IsSupported { get; }
 
     public ProcfsArpAddressTable(IServiceProvider? serviceProvider = null) {}
 
-    [AsyncIteratorStateMachine(typeof(ProcfsArpAddressTable.<EnumerateEntriesAsync>d__7))]
-    public IAsyncEnumerable<AddressTableEntry> EnumerateEntriesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default) {}
-    void IDisposable.Dispose() {}
+    [AsyncIteratorStateMachine(typeof(ProcfsArpAddressTable.<EnumerateEntriesAsyncCore>d__5))]
+    protected override IAsyncEnumerable<AddressTableEntry> EnumerateEntriesAsyncCore([EnumeratorCancellation] CancellationToken cancellationToken) {}
   }
 
   public readonly struct AddressTableEntry :
@@ -198,7 +212,7 @@ namespace Smdn.Net.NetworkScanning {
   public sealed class ArpScanCommandNetworkScanner : CommandNetworkScanner {
     public static bool IsSupported { get; }
 
-    public ArpScanCommandNetworkScanner(IPNetworkProfile? networkProfile, IServiceProvider? serviceProvider) {}
+    public ArpScanCommandNetworkScanner(IPNetworkProfile? networkProfile, IServiceProvider? serviceProvider = null) {}
 
     protected override bool GetCommandLineArguments(IEnumerable<IPAddress> addressesToScan, out string executable, out string arguments) {}
     protected override bool GetCommandLineArguments(out string executable, out string arguments) {}
@@ -230,31 +244,51 @@ namespace Smdn.Net.NetworkScanning {
     protected abstract bool GetCommandLineArguments(out string executable, out string? arguments);
     public virtual ValueTask ScanAsync(CancellationToken cancellationToken = default) {}
     public virtual ValueTask ScanAsync(IEnumerable<IPAddress> addresses, CancellationToken cancellationToken = default) {}
+    protected void ThrowIfDisposed() {}
   }
 
-  public sealed class IpHlpApiNetworkScanner : INetworkScanner {
+  public sealed class IpHlpApiNetworkScanner : NetworkScanner {
+    public static bool IsSupported { get; }
+
     public IpHlpApiNetworkScanner(IPNetworkProfile networkProfile, IServiceProvider? serviceProvider = null) {}
 
-    public ValueTask ScanAsync(CancellationToken cancellationToken = default) {}
-    public async ValueTask ScanAsync(IEnumerable<IPAddress> addresses, CancellationToken cancellationToken = default) {}
-    void IDisposable.Dispose() {}
+    protected override async ValueTask ScanAsyncCore(IPAddress address, CancellationToken cancellationToken = default) {}
+  }
+
+  public abstract class NetworkScanner : INetworkScanner {
+    public static INetworkScanner Null { get; }
+
+    public static INetworkScanner Create(IPNetworkProfile? networkProfile, IServiceProvider? serviceProvider = null) {}
+
+    protected NetworkScanner(IPNetworkProfile networkProfile, ILogger? logger = null) {}
+
+    protected ILogger? Logger { get; }
+    protected IPNetworkProfile NetworkProfile { get; }
+
+    protected virtual void Dispose(bool disposing) {}
+    public void Dispose() {}
+    public virtual ValueTask ScanAsync(CancellationToken cancellationToken = default) {}
+    public virtual ValueTask ScanAsync(IEnumerable<IPAddress> addresses, CancellationToken cancellationToken = default) {}
+    protected virtual ValueTask ScanAsyncCore(IPAddress address, CancellationToken cancellationToken) {}
+    protected void ThrowIfDisposed() {}
   }
 
   public sealed class NmapCommandNetworkScanner : CommandNetworkScanner {
     public static bool IsSupported { get; }
 
-    public NmapCommandNetworkScanner(IPNetworkProfile networkProfile, IServiceProvider? serviceProvider) {}
+    public NmapCommandNetworkScanner(IPNetworkProfile networkProfile, IServiceProvider? serviceProvider = null) {}
 
     protected override bool GetCommandLineArguments(IEnumerable<IPAddress> addressesToScan, out string executable, out string arguments) {}
     protected override bool GetCommandLineArguments(out string executable, out string arguments) {}
   }
 
-  public sealed class PingNetworkScanner : INetworkScanner {
+  public sealed class PingNetworkScanner : NetworkScanner {
+    public static bool IsSupported { get; }
+
     public PingNetworkScanner(IPNetworkProfile networkProfile, IServiceProvider? serviceProvider = null) {}
 
-    public void Dispose() {}
-    public ValueTask ScanAsync(CancellationToken cancellationToken = default) {}
-    public ValueTask ScanAsync(IEnumerable<IPAddress> addresses, CancellationToken cancellationToken = default) {}
+    protected override void Dispose(bool disposing) {}
+    protected override async ValueTask ScanAsyncCore(IPAddress address, CancellationToken cancellationToken = default) {}
   }
 }
 // API list generated by Smdn.Reflection.ReverseGenerating.ListApi.MSBuild.Tasks v1.2.1.0.

--- a/doc/api-list/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution-net7.0.apilist.cs
+++ b/doc/api-list/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution-net7.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.AddressResolution.dll (Smdn.Net.AddressResolution-1.0.0-rc1)
+// Smdn.Net.AddressResolution.dll (Smdn.Net.AddressResolution-1.0.0-rc2)
 //   Name: Smdn.Net.AddressResolution
 //   AssemblyVersion: 1.0.0.0
-//   InformationalVersion: 1.0.0-rc1+54f2767c7798db11d76ae3836009b55f701af69f
+//   InformationalVersion: 1.0.0-rc2+3ee5c5d35420506d56f36dcd2bf148727d37aa11
 //   TargetFramework: .NETCoreApp,Version=v7.0
 //   Configuration: Release
 //   Referenced assemblies:
@@ -68,9 +68,9 @@ namespace Smdn.Net.AddressResolution {
   }
 
   public class MacAddressResolver : MacAddressResolverBase {
-    protected MacAddressResolver(IAddressTable addressTable, bool shouldDisposeAddressTable, INetworkScanner? networkScanner, bool shouldDisposeNetworkScanner, NetworkInterface? networkInterface, int maxParallelCountForRefreshInvalidatedCache, ILogger? logger) {}
+    protected MacAddressResolver(IAddressTable addressTable, bool shouldDisposeAddressTable, INetworkScanner? networkScanner, bool shouldDisposeNetworkScanner, NetworkInterface? networkInterface, int maxParallelCountForRefreshInvalidatedAddresses, ILogger? logger) {}
     public MacAddressResolver() {}
-    public MacAddressResolver(IAddressTable? addressTable, INetworkScanner? networkScanner, bool shouldDisposeAddressTable = false, bool shouldDisposeNetworkScanner = false, NetworkInterface? networkInterface = null, int maxParallelCountForRefreshInvalidatedCache = 3, IServiceProvider? serviceProvider = null) {}
+    public MacAddressResolver(IAddressTable? addressTable, INetworkScanner? networkScanner, bool shouldDisposeAddressTable = false, bool shouldDisposeNetworkScanner = false, NetworkInterface? networkInterface = null, int maxParallelCountForRefreshInvalidatedAddresses = 3, IServiceProvider? serviceProvider = null) {}
     public MacAddressResolver(IPNetworkProfile? networkProfile, IServiceProvider? serviceProvider = null) {}
 
     public bool CanPerformNetworkScan { get; }
@@ -83,8 +83,8 @@ namespace Smdn.Net.AddressResolution {
     public IAsyncEnumerable<AddressTableEntry> EnumerateAddressTableEntriesAsync(Predicate<AddressTableEntry> predicate, CancellationToken cancellationToken = default) {}
     protected override void InvalidateCore(IPAddress ipAddress) {}
     protected override void InvalidateCore(PhysicalAddress macAddress) {}
-    protected override ValueTask RefreshCacheAsyncCore(CancellationToken cancellationToken = default) {}
-    protected override ValueTask RefreshInvalidatedCacheAsyncCore(CancellationToken cancellationToken = default) {}
+    protected override ValueTask RefreshAddressTableAsyncCore(CancellationToken cancellationToken = default) {}
+    protected override ValueTask RefreshInvalidatedAddressesAsyncCore(CancellationToken cancellationToken = default) {}
     protected override async ValueTask<PhysicalAddress?> ResolveIPAddressToMacAddressAsyncCore(IPAddress ipAddress, CancellationToken cancellationToken) {}
     protected override async ValueTask<IPAddress?> ResolveMacAddressToIPAddressAsyncCore(PhysicalAddress macAddress, CancellationToken cancellationToken) {}
     protected virtual async ValueTask<AddressTableEntry> SelectAddressTableEntryAsync(Predicate<AddressTableEntry> predicate, CancellationToken cancellationToken) {}
@@ -109,10 +109,10 @@ namespace Smdn.Net.AddressResolution {
     public void Invalidate(PhysicalAddress macAddress) {}
     protected abstract void InvalidateCore(IPAddress ipAddress);
     protected abstract void InvalidateCore(PhysicalAddress macAddress);
-    public ValueTask RefreshCacheAsync(CancellationToken cancellationToken = default) {}
-    protected virtual ValueTask RefreshCacheAsyncCore(CancellationToken cancellationToken) {}
-    public ValueTask RefreshInvalidatedCacheAsync(CancellationToken cancellationToken = default) {}
-    protected virtual ValueTask RefreshInvalidatedCacheAsyncCore(CancellationToken cancellationToken) {}
+    public ValueTask RefreshAddressTableAsync(CancellationToken cancellationToken = default) {}
+    protected virtual ValueTask RefreshAddressTableAsyncCore(CancellationToken cancellationToken) {}
+    public ValueTask RefreshInvalidatedAddressesAsync(CancellationToken cancellationToken = default) {}
+    protected virtual ValueTask RefreshInvalidatedAddressesAsyncCore(CancellationToken cancellationToken) {}
     public ValueTask<PhysicalAddress?> ResolveIPAddressToMacAddressAsync(IPAddress ipAddress, CancellationToken cancellationToken = default) {}
     protected abstract ValueTask<PhysicalAddress?> ResolveIPAddressToMacAddressAsyncCore(IPAddress ipAddress, CancellationToken cancellationToken);
     public ValueTask<IPAddress?> ResolveMacAddressToIPAddressAsync(PhysicalAddress macAddress, CancellationToken cancellationToken = default) {}
@@ -139,24 +139,38 @@ namespace Smdn.Net.AddressTables {
     Stale = 3,
   }
 
-  public sealed class IpHlpApiAddressTable : IAddressTable {
+  public abstract class AddressTable : IAddressTable {
+    public static IAddressTable Null { get; }
+
+    public static IAddressTable Create(IServiceProvider? serviceProvider = null) {}
+
+    protected AddressTable(ILogger? logger = null) {}
+
+    protected ILogger? Logger { get; }
+
+    protected virtual void Dispose(bool disposing) {}
+    public void Dispose() {}
+    public IAsyncEnumerable<AddressTableEntry> EnumerateEntriesAsync(CancellationToken cancellationToken = default) {}
+    protected abstract IAsyncEnumerable<AddressTableEntry> EnumerateEntriesAsyncCore(CancellationToken cancellationToken);
+    protected void ThrowIfDisposed() {}
+  }
+
+  public sealed class IpHlpApiAddressTable : AddressTable {
     public static bool IsSupported { get; }
 
     public IpHlpApiAddressTable(IServiceProvider? serviceProvider = null) {}
 
-    [AsyncIteratorStateMachine(typeof(IpHlpApiAddressTable.<EnumerateEntriesAsync>d__6))]
-    public IAsyncEnumerable<AddressTableEntry> EnumerateEntriesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default) {}
-    void IDisposable.Dispose() {}
+    [AsyncIteratorStateMachine(typeof(IpHlpApiAddressTable.<EnumerateEntriesAsyncCore>d__4))]
+    protected override IAsyncEnumerable<AddressTableEntry> EnumerateEntriesAsyncCore([EnumeratorCancellation] CancellationToken cancellationToken) {}
   }
 
-  public sealed class ProcfsArpAddressTable : IAddressTable {
+  public sealed class ProcfsArpAddressTable : AddressTable {
     public static bool IsSupported { get; }
 
     public ProcfsArpAddressTable(IServiceProvider? serviceProvider = null) {}
 
-    [AsyncIteratorStateMachine(typeof(ProcfsArpAddressTable.<EnumerateEntriesAsync>d__7))]
-    public IAsyncEnumerable<AddressTableEntry> EnumerateEntriesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default) {}
-    void IDisposable.Dispose() {}
+    [AsyncIteratorStateMachine(typeof(ProcfsArpAddressTable.<EnumerateEntriesAsyncCore>d__5))]
+    protected override IAsyncEnumerable<AddressTableEntry> EnumerateEntriesAsyncCore([EnumeratorCancellation] CancellationToken cancellationToken) {}
   }
 
   public readonly struct AddressTableEntry :
@@ -197,7 +211,7 @@ namespace Smdn.Net.NetworkScanning {
   public sealed class ArpScanCommandNetworkScanner : CommandNetworkScanner {
     public static bool IsSupported { get; }
 
-    public ArpScanCommandNetworkScanner(IPNetworkProfile? networkProfile, IServiceProvider? serviceProvider) {}
+    public ArpScanCommandNetworkScanner(IPNetworkProfile? networkProfile, IServiceProvider? serviceProvider = null) {}
 
     protected override bool GetCommandLineArguments(IEnumerable<IPAddress> addressesToScan, out string executable, out string arguments) {}
     protected override bool GetCommandLineArguments(out string executable, out string arguments) {}
@@ -229,31 +243,51 @@ namespace Smdn.Net.NetworkScanning {
     protected abstract bool GetCommandLineArguments(out string executable, out string? arguments);
     public virtual ValueTask ScanAsync(CancellationToken cancellationToken = default) {}
     public virtual ValueTask ScanAsync(IEnumerable<IPAddress> addresses, CancellationToken cancellationToken = default) {}
+    protected void ThrowIfDisposed() {}
   }
 
-  public sealed class IpHlpApiNetworkScanner : INetworkScanner {
+  public sealed class IpHlpApiNetworkScanner : NetworkScanner {
+    public static bool IsSupported { get; }
+
     public IpHlpApiNetworkScanner(IPNetworkProfile networkProfile, IServiceProvider? serviceProvider = null) {}
 
-    public ValueTask ScanAsync(CancellationToken cancellationToken = default) {}
-    public async ValueTask ScanAsync(IEnumerable<IPAddress> addresses, CancellationToken cancellationToken = default) {}
-    void IDisposable.Dispose() {}
+    protected override async ValueTask ScanAsyncCore(IPAddress address, CancellationToken cancellationToken = default) {}
+  }
+
+  public abstract class NetworkScanner : INetworkScanner {
+    public static INetworkScanner Null { get; }
+
+    public static INetworkScanner Create(IPNetworkProfile? networkProfile, IServiceProvider? serviceProvider = null) {}
+
+    protected NetworkScanner(IPNetworkProfile networkProfile, ILogger? logger = null) {}
+
+    protected ILogger? Logger { get; }
+    protected IPNetworkProfile NetworkProfile { get; }
+
+    protected virtual void Dispose(bool disposing) {}
+    public void Dispose() {}
+    public virtual ValueTask ScanAsync(CancellationToken cancellationToken = default) {}
+    public virtual ValueTask ScanAsync(IEnumerable<IPAddress> addresses, CancellationToken cancellationToken = default) {}
+    protected virtual ValueTask ScanAsyncCore(IPAddress address, CancellationToken cancellationToken) {}
+    protected void ThrowIfDisposed() {}
   }
 
   public sealed class NmapCommandNetworkScanner : CommandNetworkScanner {
     public static bool IsSupported { get; }
 
-    public NmapCommandNetworkScanner(IPNetworkProfile networkProfile, IServiceProvider? serviceProvider) {}
+    public NmapCommandNetworkScanner(IPNetworkProfile networkProfile, IServiceProvider? serviceProvider = null) {}
 
     protected override bool GetCommandLineArguments(IEnumerable<IPAddress> addressesToScan, out string executable, out string arguments) {}
     protected override bool GetCommandLineArguments(out string executable, out string arguments) {}
   }
 
-  public sealed class PingNetworkScanner : INetworkScanner {
+  public sealed class PingNetworkScanner : NetworkScanner {
+    public static bool IsSupported { get; }
+
     public PingNetworkScanner(IPNetworkProfile networkProfile, IServiceProvider? serviceProvider = null) {}
 
-    public void Dispose() {}
-    public ValueTask ScanAsync(CancellationToken cancellationToken = default) {}
-    public ValueTask ScanAsync(IEnumerable<IPAddress> addresses, CancellationToken cancellationToken = default) {}
+    protected override void Dispose(bool disposing) {}
+    protected override async ValueTask ScanAsyncCore(IPAddress address, CancellationToken cancellationToken = default) {}
   }
 }
 // API list generated by Smdn.Reflection.ReverseGenerating.ListApi.MSBuild.Tasks v1.2.1.0.

--- a/doc/api-list/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution-netstandard2.0.apilist.cs
+++ b/doc/api-list/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution-netstandard2.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.AddressResolution.dll (Smdn.Net.AddressResolution-1.0.0-rc1)
+// Smdn.Net.AddressResolution.dll (Smdn.Net.AddressResolution-1.0.0-rc2)
 //   Name: Smdn.Net.AddressResolution
 //   AssemblyVersion: 1.0.0.0
-//   InformationalVersion: 1.0.0-rc1+54f2767c7798db11d76ae3836009b55f701af69f
+//   InformationalVersion: 1.0.0-rc2+3ee5c5d35420506d56f36dcd2bf148727d37aa11
 //   TargetFramework: .NETStandard,Version=v2.0
 //   Configuration: Release
 //   Referenced assemblies:
@@ -59,9 +59,9 @@ namespace Smdn.Net.AddressResolution {
   }
 
   public class MacAddressResolver : MacAddressResolverBase {
-    protected MacAddressResolver(IAddressTable addressTable, bool shouldDisposeAddressTable, INetworkScanner? networkScanner, bool shouldDisposeNetworkScanner, NetworkInterface? networkInterface, int maxParallelCountForRefreshInvalidatedCache, ILogger? logger) {}
+    protected MacAddressResolver(IAddressTable addressTable, bool shouldDisposeAddressTable, INetworkScanner? networkScanner, bool shouldDisposeNetworkScanner, NetworkInterface? networkInterface, int maxParallelCountForRefreshInvalidatedAddresses, ILogger? logger) {}
     public MacAddressResolver() {}
-    public MacAddressResolver(IAddressTable? addressTable, INetworkScanner? networkScanner, bool shouldDisposeAddressTable = false, bool shouldDisposeNetworkScanner = false, NetworkInterface? networkInterface = null, int maxParallelCountForRefreshInvalidatedCache = 3, IServiceProvider? serviceProvider = null) {}
+    public MacAddressResolver(IAddressTable? addressTable, INetworkScanner? networkScanner, bool shouldDisposeAddressTable = false, bool shouldDisposeNetworkScanner = false, NetworkInterface? networkInterface = null, int maxParallelCountForRefreshInvalidatedAddresses = 3, IServiceProvider? serviceProvider = null) {}
     public MacAddressResolver(IPNetworkProfile? networkProfile, IServiceProvider? serviceProvider = null) {}
 
     public bool CanPerformNetworkScan { get; }
@@ -74,8 +74,8 @@ namespace Smdn.Net.AddressResolution {
     public IAsyncEnumerable<AddressTableEntry> EnumerateAddressTableEntriesAsync(Predicate<AddressTableEntry> predicate, CancellationToken cancellationToken = default) {}
     protected override void InvalidateCore(IPAddress ipAddress) {}
     protected override void InvalidateCore(PhysicalAddress macAddress) {}
-    protected override ValueTask RefreshCacheAsyncCore(CancellationToken cancellationToken = default) {}
-    protected override ValueTask RefreshInvalidatedCacheAsyncCore(CancellationToken cancellationToken = default) {}
+    protected override ValueTask RefreshAddressTableAsyncCore(CancellationToken cancellationToken = default) {}
+    protected override ValueTask RefreshInvalidatedAddressesAsyncCore(CancellationToken cancellationToken = default) {}
     protected override async ValueTask<PhysicalAddress?> ResolveIPAddressToMacAddressAsyncCore(IPAddress ipAddress, CancellationToken cancellationToken) {}
     protected override async ValueTask<IPAddress?> ResolveMacAddressToIPAddressAsyncCore(PhysicalAddress macAddress, CancellationToken cancellationToken) {}
     protected virtual async ValueTask<AddressTableEntry> SelectAddressTableEntryAsync(Predicate<AddressTableEntry> predicate, CancellationToken cancellationToken) {}
@@ -100,10 +100,10 @@ namespace Smdn.Net.AddressResolution {
     public void Invalidate(PhysicalAddress macAddress) {}
     protected abstract void InvalidateCore(IPAddress ipAddress);
     protected abstract void InvalidateCore(PhysicalAddress macAddress);
-    public ValueTask RefreshCacheAsync(CancellationToken cancellationToken = default) {}
-    protected virtual ValueTask RefreshCacheAsyncCore(CancellationToken cancellationToken) {}
-    public ValueTask RefreshInvalidatedCacheAsync(CancellationToken cancellationToken = default) {}
-    protected virtual ValueTask RefreshInvalidatedCacheAsyncCore(CancellationToken cancellationToken) {}
+    public ValueTask RefreshAddressTableAsync(CancellationToken cancellationToken = default) {}
+    protected virtual ValueTask RefreshAddressTableAsyncCore(CancellationToken cancellationToken) {}
+    public ValueTask RefreshInvalidatedAddressesAsync(CancellationToken cancellationToken = default) {}
+    protected virtual ValueTask RefreshInvalidatedAddressesAsyncCore(CancellationToken cancellationToken) {}
     public ValueTask<PhysicalAddress?> ResolveIPAddressToMacAddressAsync(IPAddress ipAddress, CancellationToken cancellationToken = default) {}
     protected abstract ValueTask<PhysicalAddress?> ResolveIPAddressToMacAddressAsyncCore(IPAddress ipAddress, CancellationToken cancellationToken);
     public ValueTask<IPAddress?> ResolveMacAddressToIPAddressAsync(PhysicalAddress macAddress, CancellationToken cancellationToken = default) {}
@@ -130,24 +130,38 @@ namespace Smdn.Net.AddressTables {
     Stale = 3,
   }
 
-  public sealed class IpHlpApiAddressTable : IAddressTable {
+  public abstract class AddressTable : IAddressTable {
+    public static IAddressTable Null { get; }
+
+    public static IAddressTable Create(IServiceProvider? serviceProvider = null) {}
+
+    protected AddressTable(ILogger? logger = null) {}
+
+    protected ILogger? Logger { get; }
+
+    protected virtual void Dispose(bool disposing) {}
+    public void Dispose() {}
+    public IAsyncEnumerable<AddressTableEntry> EnumerateEntriesAsync(CancellationToken cancellationToken = default) {}
+    protected abstract IAsyncEnumerable<AddressTableEntry> EnumerateEntriesAsyncCore(CancellationToken cancellationToken);
+    protected void ThrowIfDisposed() {}
+  }
+
+  public sealed class IpHlpApiAddressTable : AddressTable {
     public static bool IsSupported { get; }
 
     public IpHlpApiAddressTable(IServiceProvider? serviceProvider = null) {}
 
-    [AsyncIteratorStateMachine(typeof(IpHlpApiAddressTable.<EnumerateEntriesAsync>d__6))]
-    public IAsyncEnumerable<AddressTableEntry> EnumerateEntriesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default) {}
-    void IDisposable.Dispose() {}
+    [AsyncIteratorStateMachine(typeof(IpHlpApiAddressTable.<EnumerateEntriesAsyncCore>d__4))]
+    protected override IAsyncEnumerable<AddressTableEntry> EnumerateEntriesAsyncCore([EnumeratorCancellation] CancellationToken cancellationToken) {}
   }
 
-  public sealed class ProcfsArpAddressTable : IAddressTable {
+  public sealed class ProcfsArpAddressTable : AddressTable {
     public static bool IsSupported { get; }
 
     public ProcfsArpAddressTable(IServiceProvider? serviceProvider = null) {}
 
-    [AsyncIteratorStateMachine(typeof(ProcfsArpAddressTable.<EnumerateEntriesAsync>d__7))]
-    public IAsyncEnumerable<AddressTableEntry> EnumerateEntriesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default) {}
-    void IDisposable.Dispose() {}
+    [AsyncIteratorStateMachine(typeof(ProcfsArpAddressTable.<EnumerateEntriesAsyncCore>d__5))]
+    protected override IAsyncEnumerable<AddressTableEntry> EnumerateEntriesAsyncCore([EnumeratorCancellation] CancellationToken cancellationToken) {}
   }
 
   public readonly struct AddressTableEntry :
@@ -187,7 +201,7 @@ namespace Smdn.Net.NetworkScanning {
   public sealed class ArpScanCommandNetworkScanner : CommandNetworkScanner {
     public static bool IsSupported { get; }
 
-    public ArpScanCommandNetworkScanner(IPNetworkProfile? networkProfile, IServiceProvider? serviceProvider) {}
+    public ArpScanCommandNetworkScanner(IPNetworkProfile? networkProfile, IServiceProvider? serviceProvider = null) {}
 
     protected override bool GetCommandLineArguments(IEnumerable<IPAddress> addressesToScan, out string executable, out string arguments) {}
     protected override bool GetCommandLineArguments(out string executable, out string arguments) {}
@@ -219,31 +233,51 @@ namespace Smdn.Net.NetworkScanning {
     protected abstract bool GetCommandLineArguments(out string executable, out string? arguments);
     public virtual ValueTask ScanAsync(CancellationToken cancellationToken = default) {}
     public virtual ValueTask ScanAsync(IEnumerable<IPAddress> addresses, CancellationToken cancellationToken = default) {}
+    protected void ThrowIfDisposed() {}
   }
 
-  public sealed class IpHlpApiNetworkScanner : INetworkScanner {
+  public sealed class IpHlpApiNetworkScanner : NetworkScanner {
+    public static bool IsSupported { get; }
+
     public IpHlpApiNetworkScanner(IPNetworkProfile networkProfile, IServiceProvider? serviceProvider = null) {}
 
-    public ValueTask ScanAsync(CancellationToken cancellationToken = default) {}
-    public async ValueTask ScanAsync(IEnumerable<IPAddress> addresses, CancellationToken cancellationToken = default) {}
-    void IDisposable.Dispose() {}
+    protected override async ValueTask ScanAsyncCore(IPAddress address, CancellationToken cancellationToken = default) {}
+  }
+
+  public abstract class NetworkScanner : INetworkScanner {
+    public static INetworkScanner Null { get; }
+
+    public static INetworkScanner Create(IPNetworkProfile? networkProfile, IServiceProvider? serviceProvider = null) {}
+
+    protected NetworkScanner(IPNetworkProfile networkProfile, ILogger? logger = null) {}
+
+    protected ILogger? Logger { get; }
+    protected IPNetworkProfile NetworkProfile { get; }
+
+    protected virtual void Dispose(bool disposing) {}
+    public void Dispose() {}
+    public virtual ValueTask ScanAsync(CancellationToken cancellationToken = default) {}
+    public virtual ValueTask ScanAsync(IEnumerable<IPAddress> addresses, CancellationToken cancellationToken = default) {}
+    protected virtual ValueTask ScanAsyncCore(IPAddress address, CancellationToken cancellationToken) {}
+    protected void ThrowIfDisposed() {}
   }
 
   public sealed class NmapCommandNetworkScanner : CommandNetworkScanner {
     public static bool IsSupported { get; }
 
-    public NmapCommandNetworkScanner(IPNetworkProfile networkProfile, IServiceProvider? serviceProvider) {}
+    public NmapCommandNetworkScanner(IPNetworkProfile networkProfile, IServiceProvider? serviceProvider = null) {}
 
     protected override bool GetCommandLineArguments(IEnumerable<IPAddress> addressesToScan, out string executable, out string arguments) {}
     protected override bool GetCommandLineArguments(out string executable, out string arguments) {}
   }
 
-  public sealed class PingNetworkScanner : INetworkScanner {
+  public sealed class PingNetworkScanner : NetworkScanner {
+    public static bool IsSupported { get; }
+
     public PingNetworkScanner(IPNetworkProfile networkProfile, IServiceProvider? serviceProvider = null) {}
 
-    public void Dispose() {}
-    public ValueTask ScanAsync(CancellationToken cancellationToken = default) {}
-    public ValueTask ScanAsync(IEnumerable<IPAddress> addresses, CancellationToken cancellationToken = default) {}
+    protected override void Dispose(bool disposing) {}
+    protected override async ValueTask ScanAsyncCore(IPAddress address, CancellationToken cancellationToken = default) {}
   }
 }
 // API list generated by Smdn.Reflection.ReverseGenerating.ListApi.MSBuild.Tasks v1.2.1.0.


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #10](https://github.com/smdn/Smdn.Net.AddressResolution/actions/runs/4707197518).

# Release target
- package_target_tag: `new-release/main/Smdn.Net.AddressResolution-1.0.0-rc2`
- package_prevver_ref: `releases/Smdn.Net.AddressResolution-1.0.0-rc1`
- package_prevver_tag: `releases/Smdn.Net.AddressResolution-1.0.0-rc1`
- package_id: `Smdn.Net.AddressResolution`
- package_id_with_version: `Smdn.Net.AddressResolution-1.0.0-rc2`
- package_version: `1.0.0-rc2`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Net.AddressResolution-1.0.0-rc2-1681552659`
- release_tag: `releases/Smdn.Net.AddressResolution-1.0.0-rc2`
- release_prerelease: `True` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/34e37523a5449f512c91c6a528371519`](https://gist.github.com/smdn/34e37523a5449f512c91c6a528371519)
- artifact_name_nupkg: `Smdn.Net.AddressResolution.1.0.0-rc2.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec diff
```diff
--- Smdn.Net.AddressResolution.latest.nuspec
+++ Smdn.Net.AddressResolution.1.0.0-rc2.nuspec
@@ -1,40 +1,49 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Smdn.Net.AddressResolution</id>
-    <version>1.0.0-preview6</version>
+    <version>1.0.0-rc2</version>
     <title>Smdn.Net.AddressResolution</title>
     <authors>smdn</authors>
     <license type="expression">MIT</license>
     <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <icon>Smdn.Net.AddressResolution.png</icon>
     <readme>README.md</readme>
     <projectUrl>https://github.com/smdn/Smdn.Net.AddressResolution</projectUrl>
     <description>A network address resolution library for .NET. This library provides interfaces for resolving between IP addresses and MAC addresses, also provides implementations of address resolution using the ARP table provided by each platform.</description>
     <copyright>Copyright © 2022 smdn</copyright>
-    <tags>smdn.jp ARP ip-address mac-address hardware-address address-lookup address-resolution</tags>
-    <repository type="git" url="https://github.com/smdn/Smdn.Net.AddressResolution" branch="main" commit="867630e3d8768ccca99d991e9c0c1cca62c64c76" />
+    <tags>smdn.jp ARP arp-scan arp-table ip-address mac-address hardware-address address-lookup address-resolution</tags>
+    <repository type="git" url="https://github.com/smdn/Smdn.Net.AddressResolution" commit="3ee5c5d35420506d56f36dcd2bf148727d37aa11" />
     <dependencies>
       <group targetFramework="net6.0">
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Vanara.PInvoke.IpHlpApi" version="3.4.13" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="net7.0">
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Vanara.PInvoke.IpHlpApi" version="3.4.13" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.0">
+        <dependency id="Microsoft.Bcl.HashCode" version="1.0.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Vanara.PInvoke.IpHlpApi" version="3.4.13" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.1">
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Vanara.PInvoke.IpHlpApi" version="3.4.13" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>
+  <files>
+    <file src="/home/runner/work/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution/src/Smdn.Net.AddressResolution/bin/Release/net6.0/Smdn.Net.AddressResolution.dll" target="lib/net6.0/Smdn.Net.AddressResolution.dll" />
+    <file src="/home/runner/work/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution/src/Smdn.Net.AddressResolution/bin/Release/net7.0/Smdn.Net.AddressResolution.dll" target="lib/net7.0/Smdn.Net.AddressResolution.dll" />
+    <file src="/home/runner/work/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution/src/Smdn.Net.AddressResolution/bin/Release/netstandard2.0/Smdn.Net.AddressResolution.dll" target="lib/netstandard2.0/Smdn.Net.AddressResolution.dll" />
+    <file src="/home/runner/work/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution/src/Smdn.Net.AddressResolution/bin/Release/netstandard2.1/Smdn.Net.AddressResolution.dll" target="lib/netstandard2.1/Smdn.Net.AddressResolution.dll" />
+    <file src="/home/runner/work/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution/.nuget/packages/smdn.msbuild.projectassets.common/1.3.5/project/images/package-icon.png" target="Smdn.Net.AddressResolution.png" />
+    <file src="/home/runner/work/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution/src/Smdn.Net.AddressResolution/bin/Release/README.md" target="README.md" />
+  </files>
 </package>
\ No newline at end of file
```

