### PR TITLE
Release main/Smdn.Net.AddressResolution-1.0.1

### DIFF
--- a/doc/api-list/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution-net6.0.apilist.cs
+++ b/doc/api-list/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution-net6.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.AddressResolution.dll (Smdn.Net.AddressResolution-1.0.0)
+// Smdn.Net.AddressResolution.dll (Smdn.Net.AddressResolution-1.0.1)
 //   Name: Smdn.Net.AddressResolution
-//   AssemblyVersion: 1.0.0.0
-//   InformationalVersion: 1.0.0+b2ffdef7b9a768c14df101d2076bc63c12331f73
+//   AssemblyVersion: 1.0.1.0
+//   InformationalVersion: 1.0.1+12cda679d681acbeb81dac8a0cb03dbf6a3a0a3d
 //   TargetFramework: .NETCoreApp,Version=v6.0
 //   Configuration: Release
 //   Referenced assemblies:
@@ -49,6 +49,10 @@ namespace Smdn.Net {
     public static IPNetworkProfile Create(IPAddress baseAddress, int prefixLength, NetworkInterface? networkInterface = null) {}
     public static IPNetworkProfile Create(NetworkInterface networkInterface) {}
     public static IPNetworkProfile Create(Predicate<NetworkInterface> predicateForNetworkInterface) {}
+    public static IPNetworkProfile CreateFromNetworkInterface(Guid id) {}
+    public static IPNetworkProfile CreateFromNetworkInterface(PhysicalAddress physicalAddress) {}
+    public static IPNetworkProfile CreateFromNetworkInterface(string id) {}
+    public static IPNetworkProfile CreateFromNetworkInterfaceName(string name) {}
 
     protected IPNetworkProfile(NetworkInterface? networkInterface) {}
 

--- a/doc/api-list/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution-net7.0.apilist.cs
+++ b/doc/api-list/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution-net7.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.AddressResolution.dll (Smdn.Net.AddressResolution-1.0.0)
+// Smdn.Net.AddressResolution.dll (Smdn.Net.AddressResolution-1.0.1)
 //   Name: Smdn.Net.AddressResolution
-//   AssemblyVersion: 1.0.0.0
-//   InformationalVersion: 1.0.0+b2ffdef7b9a768c14df101d2076bc63c12331f73
+//   AssemblyVersion: 1.0.1.0
+//   InformationalVersion: 1.0.1+12cda679d681acbeb81dac8a0cb03dbf6a3a0a3d
 //   TargetFramework: .NETCoreApp,Version=v7.0
 //   Configuration: Release
 //   Referenced assemblies:
@@ -48,6 +48,10 @@ namespace Smdn.Net {
     public static IPNetworkProfile Create(IPAddress baseAddress, int prefixLength, NetworkInterface? networkInterface = null) {}
     public static IPNetworkProfile Create(NetworkInterface networkInterface) {}
     public static IPNetworkProfile Create(Predicate<NetworkInterface> predicateForNetworkInterface) {}
+    public static IPNetworkProfile CreateFromNetworkInterface(Guid id) {}
+    public static IPNetworkProfile CreateFromNetworkInterface(PhysicalAddress physicalAddress) {}
+    public static IPNetworkProfile CreateFromNetworkInterface(string id) {}
+    public static IPNetworkProfile CreateFromNetworkInterfaceName(string name) {}
 
     protected IPNetworkProfile(NetworkInterface? networkInterface) {}
 

--- a/doc/api-list/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution-netstandard2.0.apilist.cs
+++ b/doc/api-list/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution-netstandard2.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.AddressResolution.dll (Smdn.Net.AddressResolution-1.0.0)
+// Smdn.Net.AddressResolution.dll (Smdn.Net.AddressResolution-1.0.1)
 //   Name: Smdn.Net.AddressResolution
-//   AssemblyVersion: 1.0.0.0
-//   InformationalVersion: 1.0.0+b2ffdef7b9a768c14df101d2076bc63c12331f73
+//   AssemblyVersion: 1.0.1.0
+//   InformationalVersion: 1.0.1+12cda679d681acbeb81dac8a0cb03dbf6a3a0a3d
 //   TargetFramework: .NETStandard,Version=v2.0
 //   Configuration: Release
 //   Referenced assemblies:
@@ -39,6 +39,10 @@ namespace Smdn.Net {
     public static IPNetworkProfile Create(IPAddress baseAddress, int prefixLength, NetworkInterface? networkInterface = null) {}
     public static IPNetworkProfile Create(NetworkInterface networkInterface) {}
     public static IPNetworkProfile Create(Predicate<NetworkInterface> predicateForNetworkInterface) {}
+    public static IPNetworkProfile CreateFromNetworkInterface(Guid id) {}
+    public static IPNetworkProfile CreateFromNetworkInterface(PhysicalAddress physicalAddress) {}
+    public static IPNetworkProfile CreateFromNetworkInterface(string id) {}
+    public static IPNetworkProfile CreateFromNetworkInterfaceName(string name) {}
 
     protected IPNetworkProfile(NetworkInterface? networkInterface) {}
 

--- a/doc/api-list/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution-netstandard2.1.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.AddressResolution.dll (Smdn.Net.AddressResolution-1.0.0)
+// Smdn.Net.AddressResolution.dll (Smdn.Net.AddressResolution-1.0.1)
 //   Name: Smdn.Net.AddressResolution
-//   AssemblyVersion: 1.0.0.0
-//   InformationalVersion: 1.0.0+b2ffdef7b9a768c14df101d2076bc63c12331f73
+//   AssemblyVersion: 1.0.1.0
+//   InformationalVersion: 1.0.1+12cda679d681acbeb81dac8a0cb03dbf6a3a0a3d
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 //   Referenced assemblies:
@@ -35,6 +35,10 @@ namespace Smdn.Net {
     public static IPNetworkProfile Create(IPAddress baseAddress, int prefixLength, NetworkInterface? networkInterface = null) {}
     public static IPNetworkProfile Create(NetworkInterface networkInterface) {}
     public static IPNetworkProfile Create(Predicate<NetworkInterface> predicateForNetworkInterface) {}
+    public static IPNetworkProfile CreateFromNetworkInterface(Guid id) {}
+    public static IPNetworkProfile CreateFromNetworkInterface(PhysicalAddress physicalAddress) {}
+    public static IPNetworkProfile CreateFromNetworkInterface(string id) {}
+    public static IPNetworkProfile CreateFromNetworkInterfaceName(string name) {}
 
     protected IPNetworkProfile(NetworkInterface? networkInterface) {}
 


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #14](https://github.com/smdn/Smdn.Net.AddressResolution/actions/runs/4861339074).

# Release target
- package_target_tag: `new-release/main/Smdn.Net.AddressResolution-1.0.1`
- package_prevver_ref: `releases/Smdn.Net.AddressResolution-1.0.0`
- package_prevver_tag: `releases/Smdn.Net.AddressResolution-1.0.0`
- package_id: `Smdn.Net.AddressResolution`
- package_id_with_version: `Smdn.Net.AddressResolution-1.0.1`
- package_version: `1.0.1`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Net.AddressResolution-1.0.1-1683031599`
- release_tag: `releases/Smdn.Net.AddressResolution-1.0.1`
- release_prerelease: `False` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/3a917bdedecd1e0a6bad2274479bea24`](https://gist.github.com/smdn/3a917bdedecd1e0a6bad2274479bea24)
- artifact_name_nupkg: `Smdn.Net.AddressResolution.1.0.1.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec diff
```diff
--- Smdn.Net.AddressResolution.latest.nuspec
+++ Smdn.Net.AddressResolution.1.0.1.nuspec
@@ -1,41 +1,54 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Smdn.Net.AddressResolution</id>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <title>Smdn.Net.AddressResolution</title>
     <authors>smdn</authors>
     <license type="expression">MIT</license>
     <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <icon>Smdn.Net.AddressResolution.png</icon>
     <readme>README.md</readme>
     <projectUrl>https://github.com/smdn/Smdn.Net.AddressResolution</projectUrl>
     <description>A network address resolution library for .NET.  This library provides APIs for resolving between IP addresses and MAC addresses, mainly the `MacAddressResolver` class in the `Smdn.Net.AddressResolution` namespace.  This library also provides a functionality for referencing the system's address table such as the ARP table (`Smdn.Net.AddressTables` namespace), and a network scan functionality to refresh the address cache mainly using the installed commands (`Smdn.Net.NetworkScanning` namespace).</description>
     <copyright>Copyright © 2022 smdn</copyright>
     <tags>smdn.jp ARP arp-scan arp-table ip-address mac-address hardware-address address-lookup address-resolution</tags>
-    <repository type="git" url="https://github.com/smdn/Smdn.Net.AddressResolution" branch="main" commit="b2ffdef7b9a768c14df101d2076bc63c12331f73" />
+    <repository type="git" url="https://github.com/smdn/Smdn.Net.AddressResolution" commit="12cda679d681acbeb81dac8a0cb03dbf6a3a0a3d" />
     <dependencies>
       <group targetFramework="net6.0">
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Vanara.PInvoke.IpHlpApi" version="3.4.13" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="net7.0">
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Vanara.PInvoke.IpHlpApi" version="3.4.13" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.0">
         <dependency id="Microsoft.Bcl.HashCode" version="1.0.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Vanara.PInvoke.IpHlpApi" version="3.4.13" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.1">
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Vanara.PInvoke.IpHlpApi" version="3.4.13" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>
+  <files>
+    <file src="/home/runner/work/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution/src/Smdn.Net.AddressResolution/bin/Release/net6.0/Smdn.Net.AddressResolution.dll" target="lib/net6.0/Smdn.Net.AddressResolution.dll" />
+    <file src="/home/runner/work/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution/src/Smdn.Net.AddressResolution/bin/Release/net6.0/Smdn.Net.AddressResolution.xml" target="lib/net6.0/Smdn.Net.AddressResolution.xml" />
+    <file src="/home/runner/work/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution/src/Smdn.Net.AddressResolution/bin/Release/net7.0/Smdn.Net.AddressResolution.dll" target="lib/net7.0/Smdn.Net.AddressResolution.dll" />
+    <file src="/home/runner/work/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution/src/Smdn.Net.AddressResolution/bin/Release/net7.0/Smdn.Net.AddressResolution.xml" target="lib/net7.0/Smdn.Net.AddressResolution.xml" />
+    <file src="/home/runner/work/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution/src/Smdn.Net.AddressResolution/bin/Release/netstandard2.0/Smdn.Net.AddressResolution.dll" target="lib/netstandard2.0/Smdn.Net.AddressResolution.dll" />
+    <file src="/home/runner/work/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution/src/Smdn.Net.AddressResolution/bin/Release/netstandard2.0/Smdn.Net.AddressResolution.xml" target="lib/netstandard2.0/Smdn.Net.AddressResolution.xml" />
+    <file src="/home/runner/work/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution/src/Smdn.Net.AddressResolution/bin/Release/netstandard2.1/Smdn.Net.AddressResolution.dll" target="lib/netstandard2.1/Smdn.Net.AddressResolution.dll" />
+    <file src="/home/runner/work/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution/src/Smdn.Net.AddressResolution/bin/Release/netstandard2.1/Smdn.Net.AddressResolution.xml" target="lib/netstandard2.1/Smdn.Net.AddressResolution.xml" />
+    <file src="/home/runner/work/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution/.nuget/packages/smdn.msbuild.projectassets.common/1.3.5/project/images/package-icon.png" target="Smdn.Net.AddressResolution.png" />
+    <file src="/home/runner/work/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution/ThirdPartyNotices.md" target="ThirdPartyNotices.md" />
+    <file src="/home/runner/work/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution/src/Smdn.Net.AddressResolution/bin/Release/README.md" target="README.md" />
+  </files>
 </package>
\ No newline at end of file
```

