### PR TITLE
Add support for resolving IPv4-mapped IPv6 addresses

### DIFF
--- a/src/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution/MacAddressResolver.AddressResolution.cs
+++ b/src/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution/MacAddressResolver.AddressResolution.cs
@@ -33,7 +33,7 @@ partial class MacAddressResolver {
         if (!FilterAddressTableEntryForAddressResolution(entry))
           return false;
 
-        if (!entry.Equals(ipAddress))
+        if (!entry.Equals(ipAddress, shouldConsiderIPv4MappedIPv6Address: ShouldResolveIPv4MappedIPv6Address))
           return false;
 
         // ignore the entry that is marked as invalidated

--- a/src/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution/MacAddressResolver.cs
+++ b/src/Smdn.Net.AddressResolution/Smdn.Net.AddressResolution/MacAddressResolver.cs
@@ -162,6 +162,14 @@ public partial class MacAddressResolver : MacAddressResolverBase {
   private SemaphoreSlim partialScanSemaphore;
 
   /// <summary>
+  /// Gets or sets a value indicating whether the address resolution to be aware or not to be aware that
+  /// the IP address is an IPv4-mapped IPv6 address when resolving IP address to MAC address.
+  /// </summary>
+  /// <seealso cref="MacAddressResolverBase.ResolveIPAddressToMacAddressAsync(IPAddress, CancellationToken)" />
+  /// <seealso cref="AddressTableEntry.Equals(IPAddress?, bool)" />
+  public bool ShouldResolveIPv4MappedIPv6Address { get; set; }
+
+  /// <summary>
   /// Initializes a new instance of the <see cref="MacAddressResolver"/> class.
   /// </summary>
   public MacAddressResolver()

--- a/src/Smdn.Net.AddressResolution/Smdn.Net.AddressTables/AddressTableEntry.cs
+++ b/src/Smdn.Net.AddressResolution/Smdn.Net.AddressTables/AddressTableEntry.cs
@@ -73,11 +73,31 @@ public readonly struct AddressTableEntry : IEquatable<AddressTableEntry>, IEquat
     => DefaultEqualityComparer.Equals(this, other);
 
   public bool Equals(IPAddress? other)
-  {
-    if (IPAddress is null)
-      return other is null;
+    => Equals(other, shouldConsiderIPv4MappedIPv6Address: false);
 
-    return IPAddress.Equals(other);
+  /// <summary>
+  /// Indicates whether the member <see cref="AddressTableEntry.IPAddress"/> is equal to the IP address passed to the parameter.
+  /// </summary>
+  /// <param name="other">The <see cref="System.Net.IPAddress"/> to be compared with the <see cref="AddressTableEntry.IPAddress"/>.</param>
+  /// <param name="shouldConsiderIPv4MappedIPv6Address">
+  /// Specifies whether or not to be aware that the IP address to be an IPv4-mapped IPv6 address or not when comparing IP addresses.
+  /// </param>
+  /// <returns>
+  /// <see langword="true"/> if the <see cref="AddressTableEntry.IPAddress"/> is equal to the <paramref name="other"/> parameter; otherwise, <see langword="false"/>.
+  /// </returns>
+  public bool Equals(IPAddress? other, bool shouldConsiderIPv4MappedIPv6Address)
+  {
+    if (other is null)
+      return IPAddress is null;
+
+    if (shouldConsiderIPv4MappedIPv6Address) {
+      if (other.IsIPv4MappedToIPv6 && other.MapToIPv4().Equals(IPAddress))
+        return true;
+      if (IPAddress is not null && IPAddress.IsIPv4MappedToIPv6 && other.Equals(IPAddress.MapToIPv4()))
+        return true;
+    }
+
+    return other.Equals(IPAddress);
   }
 
   public bool Equals(PhysicalAddress? other)

--- a/tests/Smdn.Net.AddressResolution/Smdn.Net.AddressTables/AddressTableEntry.cs
+++ b/tests/Smdn.Net.AddressResolution/Smdn.Net.AddressTables/AddressTableEntry.cs
@@ -388,6 +388,94 @@ public class AddressTableEntryTests {
   public void Equals_OfIPAddress(AddressTableEntry entry, IPAddress? ipAddress, bool expected)
     => Assert.That(entry.Equals(ipAddress), Is.EqualTo(expected));
 
+  private static System.Collections.IEnumerable YieldTestCases_Equals_OfIPAddress_ShouldConsiderIPv4MappedIPv6Address()
+  {
+    var ipv4AddressEntry = new AddressTableEntry(
+      ipAddress: TestIPAddress,
+      physicalAddress: null,
+      isPermanent: true,
+      state: AddressTableEntryState.None,
+      interfaceId: null
+    );
+    var ipv4MappedIPv6AddressEntry = new AddressTableEntry(
+      ipAddress: TestIPAddress.MapToIPv6(),
+      physicalAddress: null,
+      isPermanent: true,
+      state: AddressTableEntryState.None,
+      interfaceId: null
+    );
+    IPAddress? nullIPAddress = null;
+
+    foreach (var shouldConsiderIPv4MappedIPv6Address in new[] { true, false }) {
+      yield return new object?[] {
+        ipv4AddressEntry,
+        nullIPAddress,
+        shouldConsiderIPv4MappedIPv6Address,
+        false
+      };
+      yield return new object?[] {
+        ipv4AddressEntry,
+        ipv4AddressEntry.IPAddress,
+        shouldConsiderIPv4MappedIPv6Address,
+        true
+      };
+      yield return new object?[] {
+        ipv4AddressEntry,
+        ipv4AddressEntry.IPAddress!.MapToIPv6(), // compare with IPv4-mapped IPv6 address
+        shouldConsiderIPv4MappedIPv6Address,
+        shouldConsiderIPv4MappedIPv6Address
+      };
+    }
+
+    foreach (var shouldConsiderIPv4MappedIPv6Address in new[] { true, false }) {
+      yield return new object?[] {
+        ipv4MappedIPv6AddressEntry,
+        nullIPAddress,
+        shouldConsiderIPv4MappedIPv6Address,
+        false
+      };
+      yield return new object?[] {
+        ipv4MappedIPv6AddressEntry,
+        ipv4MappedIPv6AddressEntry.IPAddress,
+        shouldConsiderIPv4MappedIPv6Address,
+        true
+      };
+      yield return new object?[] {
+        ipv4MappedIPv6AddressEntry,
+        ipv4MappedIPv6AddressEntry.IPAddress!.MapToIPv4(), // compare with IPv4-mapped IPv6 address
+        shouldConsiderIPv4MappedIPv6Address,
+        shouldConsiderIPv4MappedIPv6Address
+      };
+    }
+
+    var nullIPAddressEntry = default(AddressTableEntry);
+
+    foreach (var shouldConsiderIPv4MappedIPv6Address in new[] { true, false }) {
+      yield return new object?[] {
+        nullIPAddressEntry,
+        nullIPAddress,
+        shouldConsiderIPv4MappedIPv6Address,
+        true
+      };
+      yield return new object?[] {
+        nullIPAddressEntry,
+        TestIPAddress,
+        shouldConsiderIPv4MappedIPv6Address,
+        false
+      };
+      yield return new object?[] {
+        nullIPAddressEntry,
+        TestIPAddress.MapToIPv6(),
+        shouldConsiderIPv4MappedIPv6Address,
+        false
+      };
+    }
+  }
+
+  [TestCaseSource(nameof(YieldTestCases_Equals_OfIPAddress_ShouldConsiderIPv4MappedIPv6Address))]
+  public void Equals_OfIPAddress_ShouldConsiderIPv4MappedIPv6Address(AddressTableEntry entry, IPAddress? ipAddress, bool shouldConsiderIPv4MappedIPv6Address, bool expected)
+    => Assert.That(entry.Equals(ipAddress, shouldConsiderIPv4MappedIPv6Address), Is.EqualTo(expected));
+
   [Test]
   public void Equals_PhysicalAddressNull()
   {


### PR DESCRIPTION
### Description

The current implementation of `MacAddressResolver.ResolveIPAddressToMacAddressAsync` determines that if an entry in the address table is IPv4, the IPv4-mapped IPv6 address is not equivalent to that entry.

In order to be able to resolve IPv4-mapped IPv6 addresses to MAC addresses, this PR adds a new property `MacAddressResolver.ShouldResolveIPv4MappedIPv6Address`.

This PR also improves the `AddressTableEntry.Equals` method to be able to compare with IPv4-mapped IPv6 addresses to resolve this issue.
